### PR TITLE
Npm generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Options:
 
 **Generator Hierarchy**
 
-If a URL is given than it assumes that you are giving it a git repository. Otherwise it searches for a local generator folder and finally if no local generator is found it looks for an NPM package.
+If a URL is given than it assumes that you are giving it a git repository. Otherwise it searches for a local generator folder and finally if no local generator is found it looks for an NPM package and installs it if it does not exist.
 
 TODO: Elaborate
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ OpenAPI schema, and uses the given generator to create a client library.
 
 Arguments:
   schema                An OpenAPI schema, either a URL or a file path
-  generator             Git URL, file path or NPM package of a language-specific generator
+  generator             Git URL, file path or npm package of a language-specific generator
 
 Options:
   -e, --exclude <glob>    A glob pattern that excludes files from the generator in the output (default: "")
@@ -106,7 +106,7 @@ Options:
 
 **Generator Hierarchy**
 
-If a URL is given than it assumes that you are giving it a git repository. Otherwise it searches for a local generator folder and finally if no local generator is found it looks for an NPM package and installs it if it does not exist.
+If a URL is given than it assumes that you are giving it a git repository. Otherwise it searches for a local generator folder and finally if no local generator is found it looks for an npm package and installs it if it does not exist.
 
 TODO: Elaborate
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ OpenAPI schema, and uses the given generator to create a client library.
 
 Arguments:
   schema                An OpenAPI schema, either a URL or a file path
-  generator             Path, or git URL, to the language-specific generator
+  generator             Git URL, file path or NPM package of a language-specific generator
 
 Options:
   -e, --exclude <glob>    A glob pattern that excludes files from the generator in the output (default: "")
@@ -103,6 +103,10 @@ Options:
   -l, --logLevel <level>  Sets the logging level, options are: standard (default), verbose ('verbose', 'v' or '1') 
   -h, --help              Display help for command
 ~~~
+
+**Generator Hierarchy**
+
+If a URL is given than it assumes that you are giving it a git repository. Otherwise it searches for a local generator folder and finally if no local generator is found it looks for an NPM package.
 
 TODO: Elaborate
 

--- a/src/generate.js
+++ b/src/generate.js
@@ -141,6 +141,7 @@ async function generate(schemaPathOrUrl, generatorPathOrUrl, options) {
         shell.cd(currentPath, {silent:true});
       }
     }
+    
     log.standard("Validating generator");
     validateGenerator(generatorPath);
 

--- a/src/generate.js
+++ b/src/generate.js
@@ -133,7 +133,7 @@ async function generate(schemaPathOrUrl, generatorPathOrUrl, options) {
           log.verbose(`npm package ${generatorPathOrUrl} doesn't exist, installing package`);
           if (shell.exec(`npm install ${generatorPathOrUrl}`, {silent:true}).code !== 0) {
             throw new Error(
-              `No local generator or NPM package found using '${generatorPathOrUrl}', check that it points to a local generator or npm package`
+              `No local generator or npm package found using '${generatorPathOrUrl}', check that it points to a local generator or npm package`
             );
           }
         }
@@ -141,7 +141,7 @@ async function generate(schemaPathOrUrl, generatorPathOrUrl, options) {
         shell.cd(currentPath, {silent:true});
       }
     }
-    
+
     log.standard("Validating generator");
     validateGenerator(generatorPath);
 
@@ -247,7 +247,7 @@ async function generate(schemaPathOrUrl, generatorPathOrUrl, options) {
     if(npmPackage) {
       const currentPath = process.cwd();
       shell.cd(__dirname, {silent:true});
-      log.verbose(`Removing NPM package ${generatorPathOrUrl}`);
+      log.verbose(`Removing npm package ${generatorPathOrUrl}`);
       shell.exec(`npm uninstall ${generatorPathOrUrl}`, {silent:true});
       shell.cd(currentPath, {silent:true});
     }

--- a/src/generate.js
+++ b/src/generate.js
@@ -59,7 +59,9 @@ function loadGenerator(generatorPathOrUrl) {
     if (!fs.existsSync(generatorPath)) {
       //if no local generator, assume it is npm package name.
       log.verbose(`Checking if npm package ${generatorPathOrUrl} is installed`);
-      if (shell.exec(`npm list --depth=0 | findstr /R "+--.${generatorPathOrUrl}@[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*"`, {silent:true}).code !== 0) {
+      const currentPath = process.cwd();
+      shell.cd(__dirname, {silent:true});
+      if (!shell.exec(`npm list --depth=0`, {silent:true}).stdout.match(new RegExp(`^\\+--.${generatorPathOrUrl}@\\d+\.\\d+\.\\d+$`, 'm'))) {
         log.verbose(`npm package ${generatorPathOrUrl} doesn't exist, installing package`);
         if (shell.exec(`npm install ${generatorPathOrUrl}`, {silent:true}).code !== 0) {
           throw new Error(
@@ -67,7 +69,8 @@ function loadGenerator(generatorPathOrUrl) {
           );
         }
       }
-      generatorPath = path.resolve(`node_modules\\${generatorPathOrUrl}`);
+      generatorPath = path.resolve(`..\\node_modules\\${generatorPathOrUrl}`);
+      shell.cd(currentPath, {silent:true});
     }
   }
   return generatorPath;

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ program
   .command("forge")
   .description("Forge the API client from an OpenAPI specification. This command takes an OpenAPI schema, and uses the given generator to create a client library.")
   .argument("<schema>", "An OpenAPI schema, either a URL or a file path")
-  .argument("<generator>", "Path, or git URL, to the language-specific generator")
+  .argument("<generator>", "Git URL, file path or NPM package of a language-specific generator")
   .option(
     "-e, --exclude <glob>",
     "A glob pattern that excludes files from the generator in the output",

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ program
   .command("forge")
   .description("Forge the API client from an OpenAPI specification. This command takes an OpenAPI schema, and uses the given generator to create a client library.")
   .argument("<schema>", "An OpenAPI schema, either a URL or a file path")
-  .argument("<generator>", "Git URL, file path or NPM package of a language-specific generator")
+  .argument("<generator>", "Git URL, file path or npm package of a language-specific generator")
   .option(
     "-e, --exclude <glob>",
     "A glob pattern that excludes files from the generator in the output",


### PR DESCRIPTION
PR for https://github.com/ScottLogic/openapi-forge/issues/3

- Allow the use of npm packages for generators.
- Checks if package exists before trying to install it.
- Checks if there is a local generator before trying to find an npm module. Uses current working directory to form paths to modules.
- Install location is in node_modules directory of openapi-forge.
- Updated documentation.
- Create new function `loadGenerator()` to keep `generate()` clean and also to match `loadSchema()`.
- Change `generatorUrlOrPath `-> `generatorPathOrUrl `to align with `schemaPathOrUrl`.

