### PR TITLE
Fix Quick Start documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@
 
 This project is still in active development, these steps will be simplified and streamlined soon.
 
-Clone this repository, and install globally:
+Clone this repository, and install locally then globally:
 
 ~~~
+$ npm install
 $ npm install --global
 ~~~
 


### PR DESCRIPTION
If you only 'npm install --global' there will be missing dependencies.

As this is not an npm package yet all that npm does is in the global node_modules directory is to link to the local openapi-forge node_modules directory.

So first install locally so all dependencies are placed in local node_modules then install globally to link to global node_modules directory and allow execution of 'openapi-forge forge' command globally.