### PR TITLE
Add 'quiet' log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Options:
   -e, --exclude <glob>    A glob pattern that excludes files from the generator in the output (default: "")
   -o, --output <path>     The path where the generated client API will be written (default: ".")
   -s, --skipValidation    Skip schema validation
-  -l, --logLevel <level>  Sets the logging level, options are: standard (default), verbose ('verbose', 'v' or '1') 
+  -l, --logLevel <level>  Sets the logging level, options are: quiet ('quiet', 'q' or '0'), standard (default) ('standard', 's' or '1'), verbose ('verbose', 'v' or '2')
   -h, --help              Display help for command
 ~~~
 

--- a/src/index.js
+++ b/src/index.js
@@ -27,8 +27,8 @@ program
   )
   .option(
     "-l, --logLevel <level>",
-    "Sets the logging level, options are: standard (default), verbose ('verbose', 'v' or '1')",
-    "0"
+    "Sets the logging level, options are: quiet ('quiet', 'q' or '0'), standard (default) ('standard', 's' or '1'), verbose ('verbose', 'v' or '2')",
+    "1"
   )
   .action(async (schema, template, options) => {
     generate(schema, template, options);

--- a/src/log.js
+++ b/src/log.js
@@ -1,8 +1,9 @@
-let logLevel = 0;
+let logLevel = 1;
 
 const logLevels = {
-    standard: 0,
-    verbose: 1
+    quiet: 0,
+    standard: 1,
+    verbose: 2
 }
 
 function getLogLevel() {
@@ -10,12 +11,14 @@ function getLogLevel() {
 }
 
 function setLogLevel(level) {
-    if((level === '1') || (level === 'v') || (level === 'verbose')) logLevel = logLevels.verbose;
+    if((level === '0') || (level === 'q') || (level === 'quiet')) logLevel = logLevels.quiet;
+    if((level === '1') || (level === 's') || (level === 'standard')) logLevel = logLevels.standard;
+    if((level === '2') || (level === 'v') || (level === 'verbose')) logLevel = logLevels.verbose;
     return;
 }
 
 function standard(msg) {
-    console.log(msg);
+    if (logLevel >= logLevels.standard) console.log(msg);
     return;
 }
 


### PR DESCRIPTION
This PR is related to https://github.com/ScottLogic/openapi-forge/issues/54

Add a new log level that stops all CL output for use in automated systems. 

This is also needed for the language specific generator testing.