### PR TITLE
Test all language generators in one command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.vscode

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Options:
   -e, --exclude <glob>    A glob pattern that excludes files from the generator in the output (default: "")
   -o, --output <path>     The path where the generated client API will be written (default: ".")
   -s, --skipValidation    Skip schema validation
-  -l, --logLevel <level>  Sets the logging level, options are: standard (default), verbose ('verbose', 'v' or '1') 
+  -l, --logLevel <level>  Sets the logging level, options are: quiet ('quiet', 'q' or '0'), standard (default) ('standard', 's' or '1'), verbose ('verbose', 'v' or '2')
   -h, --help              Display help for command
 ~~~
 

--- a/src/generate.js
+++ b/src/generate.js
@@ -172,12 +172,12 @@ async function generate(schemaPathOrUrl, generatorPathOrUrl, options) {
       }
     }
 
-    if (schema && schema.components && schema.components.schemas) {
+    if (schema?.components?.schemas) {
       numberOfDiscoveredModels = Object.keys(schema.components.schemas).length;
       log.verbose(`Discovered ${brightCyanForeground}${numberOfDiscoveredModels}${resetStyling} models`);
     }
 
-    if (schema && schema.paths) {
+    if (schema?.paths) {
       numberOfDiscoveredEndpoints = Object.keys(schema.paths).length;
       log.verbose(`Discovered ${brightCyanForeground}${numberOfDiscoveredEndpoints}${resetStyling} endpoints`);
     }
@@ -280,7 +280,7 @@ async function generate(schemaPathOrUrl, generatorPathOrUrl, options) {
     log.standard(`${divider}`);
     log.standard(`              API generation ${redBackground}${blackForeground} FAILED ${resetStyling}`);
     log.standard(`${divider}`);
-    if(log.getLogLevel() === log.logLevels.standard) {
+    if(log.isStandard()) {
       log.standard(`${exception.message}`);
     } else {
       log.verbose(`${exception.stack}`);

--- a/src/generate.js
+++ b/src/generate.js
@@ -16,16 +16,6 @@ const transformers = require("./transformers");
 const SwaggerParser = require("@apidevtools/swagger-parser");
 const converter = require("swagger2openapi");
 
-// Command line output styling
-const blackForeground = "\x1b[30m";
-const brightYellowForeground = "\x1b[93m";
-const brightCyanForeground = "\x1b[96m";
-const redBackground = "\x1b[41m";
-const brightGreenBackground = "\x1b[102m";
-const resetStyling = "\x1b[0m";
-
-const divider = "\n---------------------------------------------------\n";
-
 Object.keys(helpers).forEach((helperName) => {
   Handlebars.registerHelper(helperName, helpers[helperName]);
 });
@@ -59,16 +49,16 @@ async function isValidSchema(schema) {
   try {
     await SwaggerParser.validate(cloneSchema(schema));
   } catch (errors) {
-    log.standard(`${divider}`);
-    log.standard(`            Schema validation ${redBackground}${blackForeground} FAILED ${resetStyling}`);
-    log.standard(`${divider}`);
+    log.standard(`${log.divider}`);
+    log.standard(`            Schema validation ${log.redBackground}${log.blackForeground} FAILED ${log.resetStyling}`);
+    log.standard(`${log.divider}`);
     const errorArray = Array.isArray(errors) ? errors : [errors];
     errorArray.forEach((error) => {
       let errorMessage = error.message;
       if(error.instancePath !== undefined) errorMessage +=  `at ${error.instancePath}`
       console.error(errorMessage);
     });
-    log.standard(`${divider}`);
+    log.standard(`${log.divider}`);
     return false;
   }
   return true;
@@ -174,12 +164,12 @@ async function generate(schemaPathOrUrl, generatorPathOrUrl, options) {
 
     if (schema?.components?.schemas) {
       numberOfDiscoveredModels = Object.keys(schema.components.schemas).length;
-      log.verbose(`Discovered ${brightCyanForeground}${numberOfDiscoveredModels}${resetStyling} models`);
+      log.verbose(`Discovered ${log.brightCyanForeground}${numberOfDiscoveredModels}${log.resetStyling} models`);
     }
 
     if (schema?.paths) {
       numberOfDiscoveredEndpoints = Object.keys(schema.paths).length;
-      log.verbose(`Discovered ${brightCyanForeground}${numberOfDiscoveredEndpoints}${resetStyling} endpoints`);
+      log.verbose(`Discovered ${log.brightCyanForeground}${numberOfDiscoveredEndpoints}${log.resetStyling} endpoints`);
     }
 
     // transform
@@ -218,12 +208,12 @@ async function generate(schemaPathOrUrl, generatorPathOrUrl, options) {
     const generatorTemplatesPath = generatorPath + "/template";
     const templates = fs.readdirSync(generatorTemplatesPath);
     log.verbose("");
-    log.standard(`Iterating over ${brightCyanForeground}${templates.length}${resetStyling} files`);
+    log.standard(`Iterating over ${log.brightCyanForeground}${templates.length}${log.resetStyling} files`);
     templates.forEach((file) => {
       if (options.exclude && minimatch(file, options.exclude)) {
         return;
       }
-      log.verbose(`\n${brightYellowForeground}${file}${resetStyling}`);
+      log.verbose(`\n${log.brightYellowForeground}${file}${log.resetStyling}`);
       log.verbose("Reading");
       const source = fs.readFileSync(
         `${generatorTemplatesPath}/${file}`,
@@ -269,23 +259,23 @@ async function generate(schemaPathOrUrl, generatorPathOrUrl, options) {
     }
   }
   if (exception === null) {
-    log.standard(`${divider}`);
-    log.standard(`            API generation ${brightGreenBackground}${blackForeground} SUCCESSFUL ${resetStyling}`);
-    log.standard(`${divider}`);
+    log.standard(`${log.divider}`);
+    log.standard(`            API generation ${log.brightGreenBackground}${log.blackForeground} SUCCESSFUL ${log.resetStyling}`);
+    log.standard(`${log.divider}`);
     log.standard(" Your API has been forged from the fiery furnace:");
-    log.standard(` ${brightCyanForeground}${numberOfDiscoveredModels}${resetStyling} models have been molded`);
-    log.standard(` ${brightCyanForeground}${numberOfDiscoveredEndpoints}${resetStyling} endpoints have been cast`);
-    log.standard(`${divider}`);
+    log.standard(` ${log.brightCyanForeground}${numberOfDiscoveredModels}${log.resetStyling} models have been molded`);
+    log.standard(` ${log.brightCyanForeground}${numberOfDiscoveredEndpoints}${log.resetStyling} endpoints have been cast`);
+    log.standard(`${log.divider}`);
   } else {
-    log.standard(`${divider}`);
-    log.standard(`              API generation ${redBackground}${blackForeground} FAILED ${resetStyling}`);
-    log.standard(`${divider}`);
+    log.standard(`${log.divider}`);
+    log.standard(`              API generation ${log.redBackground}${log.blackForeground} FAILED ${log.resetStyling}`);
+    log.standard(`${log.divider}`);
     if(log.isStandard()) {
       log.standard(`${exception.message}`);
     } else {
       log.verbose(`${exception.stack}`);
     }
-    log.standard(`${divider}`);
+    log.standard(`${log.divider}`);
   }
 }
 

--- a/src/generate.js
+++ b/src/generate.js
@@ -7,7 +7,6 @@ const Handlebars = require("handlebars");
 const prettier = require("prettier");
 const minimatch = require("minimatch");
 const fetch = require("node-fetch");
-const shell = require("shelljs");
 const { parse } = require("yaml");
 
 const generatorResolver = require("./generatorResolver");
@@ -84,7 +83,7 @@ async function generate(schemaPathOrUrl, generatorPathOrUrl, options) {
     log.standard(`Loading generator from '${generatorPathOrUrl}'`);
     let generatorPath;
     if (isUrl(generatorPathOrUrl)) {
-      generatorPath = generatorResolver.cloneGenerator(generatorPathOrUrl);
+      generatorPath = generatorResolver.cloneGenerator(generatorPathOrUrl, false);
     } else {
       //first check if there is a local generator
       generatorPath = path.resolve(generatorPathOrUrl);

--- a/src/generatorResolver.js
+++ b/src/generatorResolver.js
@@ -44,6 +44,7 @@ function cleanup() {
     if (temporaryFolder) {
         log.verbose(`Removing temporary folder ${temporaryFolder}`);
         fs.rmSync(temporaryFolder, { recursive: true });
+        temporaryFolder = null;
       }
       if(npmPackage) {
         const currentPath = process.cwd();
@@ -51,6 +52,7 @@ function cleanup() {
         log.verbose(`Removing npm package ${npmPackage}`);
         shell.exec(`npm uninstall ${npmPackage}`, {silent:true});
         shell.cd(currentPath, {silent:true});
+        npmPackage = null;
       }
 }
 

--- a/src/generatorResolver.js
+++ b/src/generatorResolver.js
@@ -1,0 +1,62 @@
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const shell = require("shelljs");
+
+const log = require("./log");
+
+let npmPackage;
+let temporaryFolder;
+
+function cloneGenerator(generatorPathOrUrl) {  // if the generator is specified as a git URL, clone it into a temporary directory
+    if (generatorPathOrUrl.endsWith(".git")) {
+        temporaryFolder = fs.mkdtempSync(
+            path.join(os.tmpdir(), "generator")
+        );
+        log.verbose(`Cloning generator from ${generatorPathOrUrl} to ${temporaryFolder}`);
+        shell.exec(`git clone ${generatorPathOrUrl} ${temporaryFolder}`, {silent:true});
+    } else {
+        throw new Error(
+            `Generator URL ${generatorPathOrUrl} does not end with ".git", check that the URL points to a valid generator`
+        );
+    }
+    return temporaryFolder;
+}
+
+function installGeneratorFromNPM(generatorPathOrUrl) {
+    log.verbose(`Checking if npm package ${generatorPathOrUrl} is installed`);
+    const currentPath = process.cwd();
+    shell.cd(__dirname, {silent:true});
+    if (!shell.exec(`npm list --depth=0`, {silent:true}).stdout.match(new RegExp(`^\\+--.${generatorPathOrUrl}@\\d+\.\\d+\.\\d+$`, 'm'))) {
+        npmPackage = generatorPathOrUrl;
+        log.verbose(`npm package ${generatorPathOrUrl} doesn't exist, installing package`);
+        if (shell.exec(`npm install ${generatorPathOrUrl}`, {silent:true}).code !== 0) {
+        throw new Error(
+            `No local generator or npm package found using '${generatorPathOrUrl}', check that it points to a local generator or npm package`
+        );
+        }
+    }
+    shell.cd(currentPath, {silent:true});   
+    return path.resolve(__dirname, `..\\node_modules\\${generatorPathOrUrl}`);
+}
+
+function cleanup() {
+    if (temporaryFolder) {
+        log.verbose(`Removing temporary folder ${temporaryFolder}`);
+        fs.rmSync(temporaryFolder, { recursive: true });
+      }
+      if(npmPackage) {
+        const currentPath = process.cwd();
+        shell.cd(__dirname, {silent:true});
+        log.verbose(`Removing npm package ${npmPackage}`);
+        shell.exec(`npm uninstall ${npmPackage}`, {silent:true});
+        shell.cd(currentPath, {silent:true});
+      }
+}
+
+module.exports = {
+    cloneGenerator,
+    installGeneratorFromNPM,
+    cleanup,
+    npmPackage
+};

--- a/src/generatorResolver.js
+++ b/src/generatorResolver.js
@@ -8,17 +8,23 @@ const log = require("./log");
 let npmPackage;
 let temporaryFolder;
 
-function cloneGenerator(generatorPathOrUrl) {  // if the generator is specified as a git URL, clone it into a temporary directory
-    if (generatorPathOrUrl.endsWith(".git")) {
-        temporaryFolder = fs.mkdtempSync(
-            path.join(os.tmpdir(), "generator")
-        );
-        log.verbose(`Cloning generator from ${generatorPathOrUrl} to ${temporaryFolder}`);
-        shell.exec(`git clone ${generatorPathOrUrl} ${temporaryFolder}`, {silent:true});
-    } else {
+function cloneGenerator(generatorPathOrUrl, installDependencies) {  // if the generator is specified as a git URL, clone it into a temporary directory
+    if (!generatorPathOrUrl.endsWith(".git")) {
         throw new Error(
             `Generator URL ${generatorPathOrUrl} does not end with ".git", check that the URL points to a valid generator`
         );
+    }
+    temporaryFolder = fs.mkdtempSync(
+        path.join(os.tmpdir(), "generator")
+    );
+    log.verbose(`Cloning generator from ${generatorPathOrUrl} to ${temporaryFolder}`);
+    shell.exec(`git clone ${generatorPathOrUrl} ${temporaryFolder}`, log.shellOptions);
+    if (installDependencies) {
+        const currentPath = process.cwd();
+        shell.cd(temporaryFolder, log.shellOptions);
+        log.verbose("Installing generator dependencies");
+        shell.exec(`npm install`, log.shellOptions);
+        shell.cd(currentPath, log.shellOptions);
     }
     return temporaryFolder;
 }
@@ -26,17 +32,17 @@ function cloneGenerator(generatorPathOrUrl) {  // if the generator is specified 
 function installGeneratorFromNPM(generatorPathOrUrl) {
     log.verbose(`Checking if npm package ${generatorPathOrUrl} is installed`);
     const currentPath = process.cwd();
-    shell.cd(__dirname, {silent:true});
-    if (!shell.exec(`npm list --depth=0`, {silent:true}).stdout.match(new RegExp(`^\\+--.${generatorPathOrUrl}@\\d+\.\\d+\.\\d+$`, 'm'))) {
+    shell.cd(__dirname, log.shellOptions);
+    if (!shell.exec(`npm list --depth=0`, log.shellOptions).stdout.match(new RegExp(`^\\+--.${generatorPathOrUrl}@\\d+\.\\d+\.\\d+$`, 'm'))) {
         npmPackage = generatorPathOrUrl;
         log.verbose(`npm package ${generatorPathOrUrl} doesn't exist, installing package`);
-        if (shell.exec(`npm install ${generatorPathOrUrl}`, {silent:true}).code !== 0) {
+        if (shell.exec(`npm install ${generatorPathOrUrl}`, log.shellOptions).code !== 0) {
         throw new Error(
             `No local generator or npm package found using '${generatorPathOrUrl}', check that it points to a local generator or npm package`
         );
         }
     }
-    shell.cd(currentPath, {silent:true});   
+    shell.cd(currentPath, log.shellOptions);   
     return path.resolve(__dirname, `..\\node_modules\\${generatorPathOrUrl}`);
 }
 
@@ -48,10 +54,10 @@ function cleanup() {
       }
       if(npmPackage) {
         const currentPath = process.cwd();
-        shell.cd(__dirname, {silent:true});
+        shell.cd(__dirname, log.shellOptions);
         log.verbose(`Removing npm package ${npmPackage}`);
-        shell.exec(`npm uninstall ${npmPackage}`, {silent:true});
-        shell.cd(currentPath, {silent:true});
+        shell.exec(`npm uninstall ${npmPackage}`, log.shellOptions);
+        shell.cd(currentPath, log.shellOptions);
         npmPackage = null;
       }
 }

--- a/src/generatorResolver.js
+++ b/src/generatorResolver.js
@@ -57,6 +57,5 @@ function cleanup() {
 module.exports = {
     cloneGenerator,
     installGeneratorFromNPM,
-    cleanup,
-    npmPackage
+    cleanup
 };

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 
 const { Command } = require("commander");
 const generate = require("./generate");
+const testGenerators = require("./testGenerators");
 const program = new Command();
 
 program.name("openapi-generator");
@@ -32,6 +33,33 @@ program
   )
   .action(async (schema, template, options) => {
     generate(schema, template, options);
+  });
+
+  program
+  .command("test-generators")
+  .description("Test language specific generators.")
+  .option(
+    "-g, --generators <gens>",
+    "Narrow down the generators to test. Each letter is a generator, combine letters to test multiple generators, options are: c (CSharp), t (TypeScript)", //h (PHP), p (Python), j (Java), s (JavaScript)
+    "ct"
+  )
+  // .option(
+  //   "-c, --csharp <csharpPath>",
+  //   "Sets the location of the CSharp generator. Default is the directory containing openapi-forge",
+  //   "../../openapi-forge-csharp"
+  // )
+  .option(
+    "-t, --typescript <typescriptPath>",
+    "Sets the location of the TypeScript generator. Default is a directory called 'openapi-forge-typescript' in the same location as openapi-forge",
+     "../../openapi-forge-typescript"
+  )
+  .option(
+    "-l, --logLevel <level>",
+    "Sets the logging level, options are: quiet ('quiet', 'q' or '0'), standard (default) ('standard', 's' or '1'), verbose ('verbose', 'v' or '2')",
+    "1"
+  )
+  .action(async (options) => {
+    testGenerators(options);
   });
 
 program.parse();

--- a/src/index.js
+++ b/src/index.js
@@ -43,11 +43,11 @@ program
     "Narrow down the generators to test. Each letter is a generator, combine letters to test multiple generators, options are: c (CSharp), t (TypeScript)", //h (PHP), p (Python), j (Java), s (JavaScript)
     "ct"
   )
-  // .option(
-  //   "-c, --csharp <csharpPath>",
-  //   "Sets the location of the CSharp generator. Default is the directory containing openapi-forge",
-  //   "../../openapi-forge-csharp"
-  // )
+  .option(
+    "-c, --csharp <csharpPath>",
+    "Sets the location of the CSharp generator. Default is a directory called 'openapi-forge-csharp' in the same location as openapi-forge",
+    "../../openapi-forge-csharp"
+  )
   .option(
     "-t, --typescript <typescriptPath>",
     "Sets the location of the TypeScript generator. Default is a directory called 'openapi-forge-typescript' in the same location as openapi-forge",

--- a/src/index.js
+++ b/src/index.js
@@ -45,12 +45,12 @@ program
   )
   .option(
     "-c, --csharp <csharpPath>",
-    "Sets the location of the CSharp generator. Default is a directory called 'openapi-forge-csharp' in the same location as openapi-forge",
+    "Sets the location of the CSharp generator. Default is a directory named 'openapi-forge-csharp' in the same location as openapi-forge",
     "../../openapi-forge-csharp"
   )
   .option(
     "-t, --typescript <typescriptPath>",
-    "Sets the location of the TypeScript generator. Default is a directory called 'openapi-forge-typescript' in the same location as openapi-forge",
+    "Sets the location of the TypeScript generator. Default is a directory named 'openapi-forge-typescript' in the same location as openapi-forge",
      "../../openapi-forge-typescript"
   )
   .option(

--- a/src/index.js
+++ b/src/index.js
@@ -27,8 +27,8 @@ program
   )
   .option(
     "-l, --logLevel <level>",
-    "Sets the logging level, options are: standard (default), verbose ('verbose', 'v' or '1')",
-    "0"
+    "Sets the logging level, options are: quiet ('quiet', 'q' or '0'), standard (default) ('standard', 's' or '1'), verbose ('verbose', 'v' or '2')",
+    "1"
   )
   .action(async (schema, template, options) => {
     generate(schema, template, options);

--- a/src/log.js
+++ b/src/log.js
@@ -81,5 +81,6 @@ module.exports = {
     isStandard,
     isVerbose,
     standard,
-    verbose
+    verbose,
+    logFailedTesting
 };

--- a/src/log.js
+++ b/src/log.js
@@ -17,6 +17,18 @@ function setLogLevel(level) {
     return;
 }
 
+function isQuiet() {
+    return (logLevel === logLevels.quiet) ? true : false;
+}
+
+function isStandard() {
+    return (logLevel === logLevels.standard) ? true : false;
+}
+
+function isVerbose() {
+    return (logLevel === logLevels.verbose) ? true : false;
+}
+
 function standard(msg) {
     if (logLevel >= logLevels.standard) console.log(msg);
     return;
@@ -32,6 +44,9 @@ module.exports = {
     logLevels,
     getLogLevel,
     setLogLevel,
+    isQuiet,
+    isStandard,
+    isVerbose,
     standard,
     verbose
 };

--- a/src/log.js
+++ b/src/log.js
@@ -1,8 +1,9 @@
-let logLevel = 0;
+let logLevel = 1;
 
 const logLevels = {
-    standard: 0,
-    verbose: 1
+    quiet: 0,
+    standard: 1,
+    verbose: 2
 }
 
 function getLogLevel() {
@@ -10,12 +11,14 @@ function getLogLevel() {
 }
 
 function setLogLevel(level) {
-    if((level === '1') || (level === 'v') || (level === 'verbose')) logLevel = logLevels.verbose;
+    if((level === '0') || (level === 'q') || (level === 'quiet')) logLevel = logLevels.quiet;
+    if((level === '1') || (level === 's') || (level === 'standard')) logLevel = logLevels.standard;
+    if((level === '2') || (level === 'v') || (level === 'verbose')) logLevel = logLevels.verbose;
     return;
 }
 
 function standard(msg) {
-    console.log(msg);
+    if (logLevel >= logLevels.standard) console.log(msg);
     return;
 }
 

--- a/src/log.js
+++ b/src/log.js
@@ -94,7 +94,7 @@ function logFailedForge(exception) {
     standard(`${divider}`);
     standard(`              API generation ${redBackground}${blackForeground} FAILED ${resetStyling}`);
     standard(`${divider}`);
-    if(getLogLevel() === log.logLevels.standard) {
+    if(getLogLevel() === logLevels.standard) {
       standard(`${exception.message}`);
     } else {
       verbose(`${exception.stack}`);
@@ -104,15 +104,15 @@ function logFailedForge(exception) {
 }
 
 function logFailedTesting(language, exception) {
-    log.standard(`${log.divider}`);
-    log.standard(`              ${language} testing ${log.redBackground}${log.blackForeground} FAILED ${log.resetStyling}`);
-    log.standard(`${log.divider}`);
-    if(log.isStandard()) {
-        log.standard(`${exception.message}`);
+    standard(`${divider}`);
+    standard(`              ${language} testing ${redBackground}${blackForeground} FAILED ${resetStyling}`);
+    standard(`${divider}`);
+    if(isStandard()) {
+        standard(`${exception.message}`);
     } else {
-        log.verbose(`${exception.stack}`);
+        verbose(`${exception.stack}`);
     }
-    log.standard(`${log.divider}`);
+    standard(`${divider}`);
 }
 
 module.exports = {

--- a/src/log.js
+++ b/src/log.js
@@ -11,6 +11,7 @@ const resetStyling = "\x1b[0m";
 const divider = "\n---------------------------------------------------\n";
 
 let logLevel = 1;
+let shellOptions = {};
 
 const logLevels = {
     quiet: 0,
@@ -23,10 +24,22 @@ function getLogLevel() {
 }
 
 function setLogLevel(level) {
-    if((level === '0') || (level === 'q') || (level === 'quiet')) logLevel = logLevels.quiet;
-    else if((level === '1') || (level === 's') || (level === 'standard')) logLevel = logLevels.standard;
-    else if((level === '2') || (level === 'v') || (level === 'verbose')) logLevel = logLevels.verbose;
+    if((level === '0') || (level === 'q') || (level === 'quiet')) {
+        logLevel = logLevels.quiet;
+        setSilentShell();
+    }
+    else if((level === '1') || (level === 's') || (level === 'standard')) {
+        logLevel = logLevels.standard;
+        setSilentShell();
+    }
+    else if((level === '2') || (level === 'v') || (level === 'verbose')) {
+        logLevel = logLevels.verbose;
+    }
     return;
+}
+
+function setSilentShell() {
+    shellOptions.silent = true;
 }
 
 function isQuiet() {
@@ -127,6 +140,7 @@ module.exports = {
     divider,
     logLevel,
     logLevels,
+    shellOptions,
     getLogLevel,
     setLogLevel,
     isQuiet,

--- a/src/log.js
+++ b/src/log.js
@@ -1,3 +1,15 @@
+// Command line output styling
+const blackForeground = "\x1b[30m";
+const brightYellowForeground = "\x1b[93m";
+const brightCyanForeground = "\x1b[96m";
+const redBackground = "\x1b[41m";
+const brightGreenBackground = "\x1b[102m";
+const bold = "\x1b[1m"
+const underline = "\x1b[4m"
+const resetStyling = "\x1b[0m";
+
+const divider = "\n---------------------------------------------------\n";
+
 let logLevel = 1;
 
 const logLevels = {
@@ -40,6 +52,15 @@ function verbose(msg) {
 }
 
 module.exports = {
+    blackForeground,
+    brightYellowForeground,
+    brightCyanForeground,
+    redBackground,
+    brightGreenBackground,
+    bold,
+    underline,
+    resetStyling,
+    divider,
     logLevel,
     logLevels,
     getLogLevel,

--- a/src/log.js
+++ b/src/log.js
@@ -24,8 +24,8 @@ function getLogLevel() {
 
 function setLogLevel(level) {
     if((level === '0') || (level === 'q') || (level === 'quiet')) logLevel = logLevels.quiet;
-    if((level === '1') || (level === 's') || (level === 'standard')) logLevel = logLevels.standard;
-    if((level === '2') || (level === 'v') || (level === 'verbose')) logLevel = logLevels.verbose;
+    else if((level === '1') || (level === 's') || (level === 'standard')) logLevel = logLevels.standard;
+    else if((level === '2') || (level === 'v') || (level === 'verbose')) logLevel = logLevels.verbose;
     return;
 }
 
@@ -49,6 +49,18 @@ function standard(msg) {
 function verbose(msg) {
     if (logLevel >= logLevels.verbose) console.log(msg);
     return;
+}
+
+function logFailedTesting(language, exception) {
+    log.standard(`${log.divider}`);
+    log.standard(`              ${language} testing ${log.redBackground}${log.blackForeground} FAILED ${log.resetStyling}`);
+    log.standard(`${log.divider}`);
+    if(log.isStandard()) {
+      log.standard(`${exception.message}`);
+    } else {
+      log.verbose(`${exception.stack}`);
+    }
+    log.standard(`${log.divider}`);
 }
 
 module.exports = {

--- a/src/testGenerators.js
+++ b/src/testGenerators.js
@@ -73,9 +73,9 @@ async function testGenerators(options) {
 
             log.verbose("Replacing path to generate.js");
             shell.cd("features/support", shellOptions);
-            const orgBasePath = shell.grep(/^const\sgeneratePath\s=\s".*";/, "base.ts").toString().replace("\r\n", "");
-            shell.sed("-i", /^const\sgeneratePath\s=\s".*";/, `const generatePath = "${basePath}";`, "base.ts");
-            
+            const orgBasePath = shell.grep(/^const\sgenerate\s=\srequire\(".*"\);/, "base.ts").toString().replace("\r\n", "");
+            shell.sed("-i", /^const\sgenerate\s=\srequire\(".*"\);/, `const generate = require\("${basePath}"\);`, "base.ts");
+
             log.verbose("Installing generator dependencies");
             shell.exec(`npm install`, shellOptions);
 
@@ -99,7 +99,7 @@ async function testGenerators(options) {
 
                 if(!temporaryFolder) {
                     log.standard("Setting paths to back to original values");
-                    shell.sed("-i", /^const\sgeneratePath\s=\s".*";/, orgBasePath, "base.ts");
+                    shell.sed("-i", /^const\sgenerate\s=\srequire\(".*"\);/, orgBasePath, "base.ts");
                     shell.cd("../../", shellOptions);
                     shell.sed("-i", /^const\sfeaturePath\s=\s".*";/, orgFeaturePath, "cucumber.js");
             }

--- a/src/testGenerators.js
+++ b/src/testGenerators.js
@@ -5,10 +5,6 @@ const shell = require("shelljs");
 
 const log = require("./log");
 
-//TODO: MJH do we need a loading bar or spinner? These tests take up to 60secs on my machine
-
-//TODO: SJH if give custom location, go from directory that the command was made not the file location.
-
 function Result(scenarios, passed, skipped, undefined, failed, time) {
     this.scenarios = isNaN(scenarios) ? 0 : scenarios;
     this.passed = isNaN(passed) ? 0 : passed;
@@ -18,8 +14,19 @@ function Result(scenarios, passed, skipped, undefined, failed, time) {
     this.time = time;
 }
 
+
+
 async function testGenerators(options) {
+    let temporaryFolder;
+    let generatorPath;
+    let featurePath;
+    let basePath;
+    let resultArray = {};
+
+    let shellOptions = {};
     log.setLogLevel(options.logLevel);
+    if(!log.isVerbose()) shellOptions.silent = true;
+
     const typescript = options.generators.includes("t");
     const csharp = options.generators.includes("c");
     if(!typescript && !csharp) {
@@ -27,21 +34,18 @@ async function testGenerators(options) {
             `No language to test. Please provide a language that you would like to test.`
         );
     }
-    let shellOptions = {};
-    if(!log.isVerbose()) shellOptions.silent = true;
-    let temporaryFolder;
-    let generatorPath;
-    let featurePath;
-    let basePath;
-    let resultArray = {};
-    // const currentPath = process.cwd();
+
     shell.cd(__dirname, shellOptions);
     if(typescript) {
+        // Test TypeScript generator
         try {
             featurePath = "../openapi-forge/features/*.feature";
             basePath = "../../../openapi-forge/src/generate";
-            // Test TypeScript generator
             generatorPath = options.typescript;
+
+            log.standard(`Loading TypeScript generator from '${generatorPath}'`);
+
+            // Check for local Typescript generator.
             if (!fs.existsSync(generatorPath)) {
                 log.verbose("Cannot find TypeScript generator");
                 if(process.argv.includes("-t") || process.argv.includes("--typescript")) {
@@ -49,70 +53,76 @@ async function testGenerators(options) {
                         `No local language generator found at ${generatorPath}.`
                     );
                 }
-                // Local generator does not exist, clone from GitHub
+                // Local generator does not exist, clone from GitHub to temporary location
                 generatorPath = temporaryFolder = fs.mkdtempSync(
                     path.join(os.tmpdir(), "generator")
                 );
-                //TODO: Change URL back to ScottLogic
-                log.verbose(`Cloning generator from https://github.com/jhowlett-scottlogic/openapi-forge-typescript.git to ${generatorPath}`);
-                shell.exec(`git clone https://github.com/jhowlett-scottlogic/openapi-forge-typescript.git ${generatorPath}`, shellOptions);
+                log.verbose(`Cloning generator from https://github.com/ScottLogic/openapi-forge-typescript.git to ${generatorPath}`);
+                shell.exec(`git clone https://github.com/ScottLogic/openapi-forge-typescript.git ${generatorPath}`, shellOptions);
+
                 // Get original paths
                 featurePath = path.relative(generatorPath, path.join(__dirname, "../features/*.feature")).replaceAll("\\", "/");
                 basePath = path.relative(path.join(generatorPath, "features/support"), path.join(__dirname, "../src/generate")).replaceAll("\\", "/");
             }
-            shell.cd(generatorPath, shellOptions);
             log.verbose("Replacing path to .feature files");
+            shell.cd(generatorPath, shellOptions);
             const orgFeaturePath = shell.grep(/^const\sfeaturePath\s=\s".*";/, "cucumber.js").toString().replace("\r\n", "");
             shell.sed("-i", /^const\sfeaturePath\s=\s".*";/, `const featurePath = "${featurePath}";`, "cucumber.js");
 
-            shell.cd("features/support", shellOptions);
-
             log.verbose("Replacing path to generate.js");
+            shell.cd("features/support", shellOptions);
             const orgBasePath = shell.grep(/^const\sgeneratePath\s=\s".*";/, "base.ts").toString().replace("\r\n", "");
             shell.sed("-i", /^const\sgeneratePath\s=\s".*";/, `const generatePath = "${basePath}";`, "base.ts");
             
             log.verbose("Installing generator dependencies");
             shell.exec(`npm install`, shellOptions);
 
-            // Run tests
-            log.verbose("Starting tests");
+            log.standard("Starting tests");
             const test = shell.exec(`npm run test`, shellOptions);
             const stdout = test.stdout.split("\n");
             const stdoutLength = stdout.length;
-
+            
+            // Format the output of the testing.
             let result = stdout[stdoutLength-2].match(/^(\d+)m(\d+)\.\d+s/);
 
             let time = "";
-            if((result[1] !== "0") && (result[1] !== "")) { time = `${result[1]}m`}
+            if((result[1] !== "0") && (result[1] !== "")) time = `${result[1]}m`;
             time = `${time}${result[2]}s` 
 
             result = stdout[stdoutLength-4].match(/^(\d+)\sscenarios?\s\(((\d+)\sfailed)?(,\s)?((\d+)\sundefined)?(,\s)?((\d+)\spassed)?\)/);
             
             resultArray.TypeScript = new Result(parseInt(result[1]), parseInt(result[9]), 0, parseInt(result[6]), parseInt(result[3]), time);
 
-            //duration line
-            //format of line: "0m11.371s"
-            //  console.log(stdout[stdoutLength-2]);
             if(!temporaryFolder) {
-                // Using local version, set paths back to original values
+                log.standard("Setting paths to back to original values");
                 shell.sed("-i", /^const\sgeneratePath\s=\s".*";/, orgBasePath, "base.ts");
                 shell.cd("../../", shellOptions);
                 shell.sed("-i", /^const\sfeaturePath\s=\s".*";/, orgFeaturePath, "cucumber.js");
             }
             shell.cd(__dirname, shellOptions);
-        } catch(e) {
-            console.log("ERROR:" + e.message);
+        } catch(exception) {
+            if(log.isStandard()) {
+                log.standard(`${exception.message}`);
+              } else {
+                log.verbose(`${exception.stack}`);
+              }
         } finally {
             if (temporaryFolder) {
+                // Using cloned version, delete temporary directory
                 fs.rmSync(temporaryFolder, { recursive: true });
                 temporaryFolder = null;
             }
         }
     }
     if(csharp) {
+        // Test CSharp generator
         try {
             featurePath = "$(ProjectDir)..\\..\\..\\openapi-forge\\features\\*.feature";
             generatorPath = options.csharp;
+
+            log.standard(`Loading CSharp generator from '${generatorPath}'`);
+
+            // Check for local CSharp generator.
             if (!fs.existsSync(generatorPath)) {
                 log.verbose("Cannot find CSharp generator");
                 if(process.argv.includes("-c") || process.argv.includes("--csharp")) {
@@ -120,6 +130,7 @@ async function testGenerators(options) {
                         `No local language generator found at ${generatorPath}.`
                     );
                 }
+                // Local generator does not exist, clone from GitHub to temporary location
                 generatorPath = temporaryFolder = fs.mkdtempSync(
                     path.join(os.tmpdir(), "generator")
                 );
@@ -130,15 +141,21 @@ async function testGenerators(options) {
                     fs.rmSync(path.join(generatorPath, "tests/FeaturesTests/bin"), { recursive: true, force: true });
                 }
             }
-            shell.cd(path.join(generatorPath, "tests/FeaturesTests"), shellOptions);
 
-            // Change path to feature files. 
+            log.standard("Replacing paths in CSharp generator")
+            
+            log.verbose("Replacing path to .feature files");
+            shell.cd(path.join(generatorPath, "tests/FeaturesTests"), shellOptions);
             const orgFeaturePath = shell.grep(/^        <FeatureFiles Include=".*" \/>/, "FeaturesTests.csproj").toString().replace("\r\n", "");
             shell.sed("-i", /^        <FeatureFiles Include=".*" \/>/, `        <FeatureFiles Include="${featurePath}" />`, "FeaturesTests.csproj");
+           
+            log.verbose("Installing generator dependencies");
             shell.exec(`npm install`, shellOptions);
 
+            log.standard("Starting tests");
             const test = shell.exec(`npm run test`, shellOptions);
 
+            // Format the output of the testing.
             const stdout = test.stdout.split("\n");
 
             let match = stdout[stdout.length-2].match(/Failed:\s+(\d+),\sPassed:\s+(\d+),\sSkipped:\s+(\d+),\sTotal:\s+(\d+),\sDuration:\s+(.*)\s-\sFeaturesTests.dll\s\(net6\.0\)/);
@@ -146,18 +163,25 @@ async function testGenerators(options) {
             resultArray.CSharp = new Result(parseInt(match[4]), parseInt(match[2]), parseInt(match[3]), 0, parseInt(match[1]), match[5].replace(" ", ""));
             
             if(!temporaryFolder) {
+                log.standard("Setting paths to back to original values");
                 shell.sed("-i", /^        <FeatureFiles Include=".*" \/>/, orgFeaturePath, "FeaturesTests.csproj");
             }
             shell.cd(__dirname, shellOptions);
-        } catch(e) {
-            console.log("ERROR: " + e.message);
+        } catch(exception) {
+            if(log.isStandard()) {
+                log.standard(`${exception.message}`);
+              } else {
+                log.verbose(`${exception.stack}`);
+              }
         } finally {
             if (temporaryFolder) {
+                // Using cloned version, delete temporary directory
                 fs.rmSync(temporaryFolder, { recursive: true });
                 temporaryFolder = null;
             }
         }
     }
+    //Present the results of the testing
     if(!log.isQuiet()) console.table(resultArray);
 }
 

--- a/src/testGenerators.js
+++ b/src/testGenerators.js
@@ -1,46 +1,164 @@
 const fs = require("fs");
-const URL = require("url").URL;
 const path = require("path");
 const os = require("os");
-
 const shell = require("shelljs");
+
 const log = require("./log");
+
+//TODO: MJH do we need a loading bar or spinner? These tests take up to 60secs on my machine
+
+//TODO: SJH if give custom location, go from directory that the command was made not the file location.
+
+function Result(scenarios, passed, skipped, undefined, failed, time) {
+    this.scenarios = isNaN(scenarios) ? 0 : scenarios;
+    this.passed = isNaN(passed) ? 0 : passed;
+    this.skipped = isNaN(skipped) ? 0 : skipped;
+    this.undefined = isNaN(undefined) ? 0 : undefined;
+    this.failed = isNaN(failed) ? 0 : failed;
+    this.time = time;
+}
 
 async function testGenerators(options) {
     log.setLogLevel(options.logLevel);
+    const typescript = options.generators.includes("t");
+    const csharp = options.generators.includes("c");
+    if(!typescript && !csharp) {
+        throw new Error(
+            `No language to test. Please provide a language that you would like to test.`
+        );
+    }
     let shellOptions = {};
-    if(log.getLogLevel() != (log.logLevels.verbose)) shellOptions.silent = true;
+    if(!log.isVerbose()) shellOptions.silent = true;
     let temporaryFolder;
     let generatorPath;
+    let featurePath;
+    let basePath;
+    let resultArray = {};
     // const currentPath = process.cwd();
-    try {
-        //TODO: SJH look into 'async' for shell.js maybe async test all generators?
-        shell.cd(__dirname, shellOptions);
-        if(options.generators.includes("t")) {
+    shell.cd(__dirname, shellOptions);
+    if(typescript) {
+        try {
+            featurePath = "../openapi-forge/features/*.feature";
+            basePath = "../../../openapi-forge/src/generate";
+            // Test TypeScript generator
             generatorPath = options.typescript;
             if (!fs.existsSync(generatorPath)) {
+                log.verbose("Cannot find TypeScript generator");
+                if(process.argv.includes("-t") || process.argv.includes("--typescript")) {
+                    throw new Error(
+                        `No local language generator found at ${generatorPath}.`
+                    );
+                }
+                // Local generator does not exist, clone from GitHub
                 generatorPath = temporaryFolder = fs.mkdtempSync(
                     path.join(os.tmpdir(), "generator")
                 );
-                shell.exec(`git clone https://github.com/ScottLogic/openapi-forge-typescript.git ${generatorPath}`, shellOptions);
+                //TODO: Change URL back to ScottLogic
+                log.verbose(`Cloning generator from https://github.com/jhowlett-scottlogic/openapi-forge-typescript.git to ${generatorPath}`);
+                shell.exec(`git clone https://github.com/jhowlett-scottlogic/openapi-forge-typescript.git ${generatorPath}`, shellOptions);
+                // Get original paths
+                featurePath = path.relative(generatorPath, path.join(__dirname, "../features/*.feature")).replaceAll("\\", "/");
+                basePath = path.relative(path.join(generatorPath, "features/support"), path.join(__dirname, "../src/generate")).replaceAll("\\", "/");
             }
             shell.cd(generatorPath, shellOptions);
-            const out = shell.exec(`npm run test`, shellOptions).stdout.split("\n");
-            //scenarios line
-            console.log(out[out.length-4]);
-            //steps line
-            console.log(out[out.length-3]);
+            log.verbose("Replacing path to .feature files");
+            const orgFeaturePath = shell.grep(/^const\sfeaturePath\s=\s".*";/, "cucumber.js").toString().replace("\r\n", "");
+            shell.sed("-i", /^const\sfeaturePath\s=\s".*";/, `const featurePath = "${featurePath}";`, "cucumber.js");
+
+            shell.cd("features/support", shellOptions);
+
+            log.verbose("Replacing path to generate.js");
+            const orgBasePath = shell.grep(/^const\sgeneratePath\s=\s".*";/, "base.ts").toString().replace("\r\n", "");
+            shell.sed("-i", /^const\sgeneratePath\s=\s".*";/, `const generatePath = "${basePath}";`, "base.ts");
+            
+            log.verbose("Installing generator dependencies");
+            shell.exec(`npm install`, shellOptions);
+
+            // Run tests
+            log.verbose("Starting tests");
+            const test = shell.exec(`npm run test`, shellOptions);
+            const stdout = test.stdout.split("\n");
+            const stdoutLength = stdout.length;
+
+            let result = stdout[stdoutLength-2].match(/^(\d+)m(\d+)\.\d+s/);
+
+            let time = "";
+            if((result[1] !== "0") && (result[1] !== "")) { time = `${result[1]}m`}
+            time = `${time}${result[2]}s` 
+
+            result = stdout[stdoutLength-4].match(/^(\d+)\sscenarios?\s\(((\d+)\sfailed)?(,\s)?((\d+)\sundefined)?(,\s)?((\d+)\spassed)?\)/);
+            
+            resultArray.TypeScript = new Result(parseInt(result[1]), parseInt(result[9]), 0, parseInt(result[6]), parseInt(result[3]), time);
+
             //duration line
-            console.log(out[out.length-2]);
+            //format of line: "0m11.371s"
+            //  console.log(stdout[stdoutLength-2]);
+            if(!temporaryFolder) {
+                // Using local version, set paths back to original values
+                shell.sed("-i", /^const\sgeneratePath\s=\s".*";/, orgBasePath, "base.ts");
+                shell.cd("../../", shellOptions);
+                shell.sed("-i", /^const\sfeaturePath\s=\s".*";/, orgFeaturePath, "cucumber.js");
+            }
             shell.cd(__dirname, shellOptions);
-        }
-    } catch(e) {
-        console.log(e.message);
-    } finally {
-        if (temporaryFolder) {
-            fs.rmSync(temporaryFolder, { recursive: true });
+        } catch(e) {
+            console.log("ERROR:" + e.message);
+        } finally {
+            if (temporaryFolder) {
+                fs.rmSync(temporaryFolder, { recursive: true });
+                temporaryFolder = null;
+            }
         }
     }
+    if(csharp) {
+        try {
+            featurePath = "$(ProjectDir)..\\..\\..\\openapi-forge\\features\\*.feature";
+            generatorPath = options.csharp;
+            if (!fs.existsSync(generatorPath)) {
+                log.verbose("Cannot find CSharp generator");
+                if(process.argv.includes("-c") || process.argv.includes("--csharp")) {
+                    throw new Error(
+                        `No local language generator found at ${generatorPath}.`
+                    );
+                }
+                generatorPath = temporaryFolder = fs.mkdtempSync(
+                    path.join(os.tmpdir(), "generator")
+                );
+                shell.exec(`git clone https://github.com/ScottLogic/openapi-forge-csharp.git ${generatorPath}`, shellOptions);
+                featurePath = "$(ProjectDir)" + path.relative(path.join(generatorPath, "tests/FeaturesTests"), path.join(__dirname, "..\\features\\*.feature"));
+            } else {
+                if (fs.existsSync(path.join(generatorPath, "tests/FeaturesTests/bin"))) {
+                    fs.rmSync(path.join(generatorPath, "tests/FeaturesTests/bin"), { recursive: true, force: true });
+                }
+            }
+            shell.cd(path.join(generatorPath, "tests/FeaturesTests"), shellOptions);
+
+            // Change path to feature files. 
+            const orgFeaturePath = shell.grep(/^        <FeatureFiles Include=".*" \/>/, "FeaturesTests.csproj").toString().replace("\r\n", "");
+            shell.sed("-i", /^        <FeatureFiles Include=".*" \/>/, `        <FeatureFiles Include="${featurePath}" />`, "FeaturesTests.csproj");
+            shell.exec(`npm install`, shellOptions);
+
+            const test = shell.exec(`npm run test`, shellOptions);
+
+            const stdout = test.stdout.split("\n");
+
+            let match = stdout[stdout.length-2].match(/Failed:\s+(\d+),\sPassed:\s+(\d+),\sSkipped:\s+(\d+),\sTotal:\s+(\d+),\sDuration:\s+(.*)\s-\sFeaturesTests.dll\s\(net6\.0\)/);
+            
+            resultArray.CSharp = new Result(parseInt(match[4]), parseInt(match[2]), parseInt(match[3]), 0, parseInt(match[1]), match[5].replace(" ", ""));
+            
+            if(!temporaryFolder) {
+                shell.sed("-i", /^        <FeatureFiles Include=".*" \/>/, orgFeaturePath, "FeaturesTests.csproj");
+            }
+            shell.cd(__dirname, shellOptions);
+        } catch(e) {
+            console.log("ERROR: " + e.message);
+        } finally {
+            if (temporaryFolder) {
+                fs.rmSync(temporaryFolder, { recursive: true });
+                temporaryFolder = null;
+            }
+        }
+    }
+    if(!log.isQuiet()) console.table(resultArray);
 }
 
 module.exports = testGenerators;

--- a/src/testGenerators.js
+++ b/src/testGenerators.js
@@ -7,6 +7,8 @@ const log = require("./log");
 const testResultParser = require("./testResultParser");
 const generatorResolver = require("./generatorResolver");
 
+let shellOptions;
+
 function checkLocalGenerator(language, languageLetter, languageString) {
     if(process.argv.includes(languageLetter) || process.argv.includes(languageString)) {
         throw new Error(
@@ -30,8 +32,8 @@ async function testGenerators(options) {
     let featurePath;
     let basePath;
     let resultArray = {};
+    shellOptions = {};
 
-    let shellOptions = {};
     log.setLogLevel(options.logLevel);
     if(!log.isVerbose()) shellOptions.silent = true;
 

--- a/src/testGenerators.js
+++ b/src/testGenerators.js
@@ -18,8 +18,7 @@ const typescriptData = {
 const csharpData = {
     languageString: "CSharp",
     languageLetter: "c",
-    generatorURL: "https://github.com/jhowlett-scottLogic/openapi-forge-csharp.git:1169047f9864f95504b4c9ac857c3ca9c2ad487c"
-    // generatorURL: "https://github.com/ScottLogic/openapi-forge-csharp.git"
+    generatorURL: "https://github.com/ScottLogic/openapi-forge-csharp.git"
 }
 
 function setupAndStartTests(generatorPath, arg1, arg2) {
@@ -34,11 +33,11 @@ function setupAndStartTests(generatorPath, arg1, arg2) {
 
 function getGenerator(languageData, generatorOption) {
     log.standard(`\n${log.bold}${log.underline}${languageData.languageString}${log.resetStyling}`);
-    let generatorPath = generatorOption;
+    let generatorPath = path.resolve(path.join("../../../", generatorOption));
 
     log.standard(`Loading ${languageData.languageString} generator from '${generatorPath}'`);
 
-    // Check for local Typescript generator.
+    // Check for local generator.
     if (!fs.existsSync(generatorPath)) {
         log.verbose(`Cannot find ${languageData.languageString} generator`);
 
@@ -55,7 +54,6 @@ function getGenerator(languageData, generatorOption) {
 }
 
 async function testGenerators(options) {
-    let generatorPath;
     let resultArray = {};
 
     log.setLogLevel(options.logLevel);
@@ -72,7 +70,7 @@ async function testGenerators(options) {
     if(typescript) {
         // Test TypeScript generator
         try {
-            generatorPath = getGenerator(typescriptData, options.typescript);
+            const generatorPath = getGenerator(typescriptData, options.typescript);
 
             const featurePath = path.relative(generatorPath, path.join(__dirname, "../features/*.feature")).replaceAll("\\", "/");
             const basePath = path.relative(path.join(generatorPath, "features/support"), path.join(__dirname, "../src/generate")).replaceAll("\\", "/");
@@ -92,7 +90,7 @@ async function testGenerators(options) {
     if(csharp) {
         // Test CSharp generator
         try {
-            generatorPath = getGenerator(csharpData, options.csharp);
+            const generatorPath = getGenerator(csharpData, options.csharp);
 
             const featurePath = path.relative(path.join(generatorPath, "tests/FeaturesTests"), path.join(__dirname, "..\\features\\*.feature"));
 

--- a/src/testGenerators.js
+++ b/src/testGenerators.js
@@ -1,0 +1,46 @@
+const fs = require("fs");
+const URL = require("url").URL;
+const path = require("path");
+const os = require("os");
+
+const shell = require("shelljs");
+const log = require("./log");
+
+async function testGenerators(options) {
+    log.setLogLevel(options.logLevel);
+    let shellOptions = {};
+    if(log.getLogLevel() != (log.logLevels.verbose)) shellOptions.silent = true;
+    let temporaryFolder;
+    let generatorPath;
+    // const currentPath = process.cwd();
+    try {
+        //TODO: SJH look into 'async' for shell.js maybe async test all generators?
+        shell.cd(__dirname, shellOptions);
+        if(options.generators.includes("t")) {
+            generatorPath = options.typescript;
+            if (!fs.existsSync(generatorPath)) {
+                generatorPath = temporaryFolder = fs.mkdtempSync(
+                    path.join(os.tmpdir(), "generator")
+                );
+                shell.exec(`git clone https://github.com/ScottLogic/openapi-forge-typescript.git ${generatorPath}`, shellOptions);
+            }
+            shell.cd(generatorPath, shellOptions);
+            const out = shell.exec(`npm run test`, shellOptions).stdout.split("\n");
+            //scenarios line
+            console.log(out[out.length-4]);
+            //steps line
+            console.log(out[out.length-3]);
+            //duration line
+            console.log(out[out.length-2]);
+            shell.cd(__dirname, shellOptions);
+        }
+    } catch(e) {
+        console.log(e.message);
+    } finally {
+        if (temporaryFolder) {
+            fs.rmSync(temporaryFolder, { recursive: true });
+        }
+    }
+}
+
+module.exports = testGenerators;

--- a/src/testResultParser.js
+++ b/src/testResultParser.js
@@ -1,0 +1,63 @@
+function Result(scenarios, passed, skipped, undefined, failed, time) {
+    this.scenarios = scenarios;
+    this.passed = passed;
+    this.skipped = skipped;
+    this.undefined = undefined;
+    this.failed = failed;
+    this.time = time;
+}
+
+function parseTestResultNumber(number) {
+    const result = parseInt(number);
+    return isNaN(result) ? 0 : result;
+}
+
+function parseTypeScript(durationLine, resultLine) {
+
+    // Extract the duration of the testing from stdout.
+    const durationMatch = durationLine.match(/^(\d+)m(\d+)\.\d+s/);
+    
+    let result;
+    if(durationMatch) {
+        // Format the duration
+        let time = "";
+        if((durationMatch[1] !== "0") && (durationMatch[1] !== "")) time = `${durationMatch[1]}m`;
+        time = `${time}${durationMatch[2]}s`;
+
+        // Extract the results of the testing from stdout.
+        const resultMatch = resultLine.match(/^(\d+)\sscenarios?\s\(((\d+)\sfailed)?(,\s)?((\d+)\sundefined)?(,\s)?((\d+)\spassed)?\)/);
+        if(resultMatch) {
+            result = new Result(parseTestResultNumber(resultMatch[1]), parseTestResultNumber(resultMatch[9]), 0, parseTestResultNumber(resultMatch[6]), parseTestResultNumber(resultMatch[3]), time);
+        } else {
+            throw new Error(
+                `Could not parse the results of the TypeScript testing.`
+            );
+        }
+    } else {
+        throw new Error(
+            `Could not parse the duration of the TypeScript testing.`
+        );
+    }
+    return result;
+}
+
+function parseCSharp(resultLine) {
+
+    // Extract the results of the testing from stdout.
+    const resultMatch = resultLine.match(/Failed:\s+(\d+),\sPassed:\s+(\d+),\sSkipped:\s+(\d+),\sTotal:\s+(\d+),\sDuration:\s+(.*)\s-\sFeaturesTests.dll\s\(net6\.0\)/);
+        
+    let result;
+    if(resultMatch) {
+        result = new Result(parseInt(resultMatch[4]), parseInt(resultMatch[2]), parseInt(resultMatch[3]), 0, parseInt(resultMatch[1]), resultMatch[5].replace(" ", ""));
+    } else {
+        throw new Error(
+            `Could not parse the results of the CSharp testing.`
+        );
+    }
+    return result;
+}
+
+module.exports =  {
+    parseTypeScript,
+    parseCSharp
+};

--- a/src/testResultParser.js
+++ b/src/testResultParser.js
@@ -1,10 +1,12 @@
-function Result(scenarios, passed, skipped, undefined, failed, time) {
-    this.scenarios = scenarios;
-    this.passed = passed;
-    this.skipped = skipped;
-    this.undefined = undefined;
-    this.failed = failed;
-    this.time = time;
+class Result {
+    constructor(scenarios, passed, skipped, undefined, failed, time) {
+        this.scenarios = scenarios;
+        this.passed = passed;
+        this.skipped = skipped;
+        this.undefined = undefined;
+        this.failed = failed;
+        this.time = time;
+    }
 }
 
 function parseTestResultNumber(number) {

--- a/src/testResultParser.js
+++ b/src/testResultParser.js
@@ -26,7 +26,7 @@ function parseTypeScript(durationLine, resultLine) {
         if((durationMatch[1] !== "0") && (durationMatch[1] !== "")) time = `${durationMatch[1]}m`;
         time = `${time}${durationMatch[2]}s`;
 
-        // Extract the results of the testing from stdout.
+        // Extract the results of the testing from stdout. In stdout is a count of tests and their outcomes.
         const resultMatch = resultLine.match(/^(\d+)\sscenarios?\s\(((\d+)\sfailed)?(,\s)?((\d+)\sundefined)?(,\s)?((\d+)\spassed)?\)/);
         if(resultMatch) {
             result = new Result(parseTestResultNumber(resultMatch[1]), parseTestResultNumber(resultMatch[9]), 0, parseTestResultNumber(resultMatch[6]), parseTestResultNumber(resultMatch[3]), time);
@@ -45,7 +45,7 @@ function parseTypeScript(durationLine, resultLine) {
 
 function parseCSharp(resultLine) {
 
-    // Extract the results of the testing from stdout.
+    // Extract the results of the testing from stdout. In stdout is a count of tests and their outcomes. Also included is the test duration.
     const resultMatch = resultLine.match(/Failed:\s+(\d+),\sPassed:\s+(\d+),\sSkipped:\s+(\d+),\sTotal:\s+(\d+),\sDuration:\s+(.*)\s-\sFeaturesTests.dll\s\(net6\.0\)/);
         
     let result;


### PR DESCRIPTION
PR related to issue  https://github.com/ScottLogic/openapi-forge/issues/10

PR related to PR https://github.com/ScottLogic/openapi-forge-typescript/pull/8

Using openapi-forge test-generators you can test all language generators and then have a table of results presented. 

This command searches for a local language generators or uses the version hosted on GitHub.