### PR TITLE
fix custom path in test-generators command

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,12 +46,12 @@ program
   .option(
     "-c, --csharp <csharpPath>",
     "Sets the location of the CSharp generator. Default is a directory named 'openapi-forge-csharp' in the same location as openapi-forge",
-    "../../openapi-forge-csharp"
+    "./openapi-forge-csharp"
   )
   .option(
     "-t, --typescript <typescriptPath>",
     "Sets the location of the TypeScript generator. Default is a directory named 'openapi-forge-typescript' in the same location as openapi-forge",
-     "../../openapi-forge-typescript"
+     "./openapi-forge-typescript"
   )
   .option(
     "-l, --logLevel <level>",

--- a/src/testGenerators.js
+++ b/src/testGenerators.js
@@ -33,7 +33,7 @@ function setupAndStartTests(generatorPath, arg1, arg2) {
 
 function getGenerator(languageData, generatorOption) {
     log.standard(`\n${log.bold}${log.underline}${languageData.languageString}${log.resetStyling}`);
-    let generatorPath = path.resolve(path.join("../../../", generatorOption));
+    let generatorPath = path.resolve(path.join("../../", generatorOption));
 
     log.standard(`Loading ${languageData.languageString} generator from '${generatorPath}'`);
 


### PR DESCRIPTION
fix bug found when demoing feature to team.

The default and custom paths to local generators were resolving incorrectly.