### PR TITLE
test: single quotes are not valid JSON

### DIFF
--- a/features/objects.feature
+++ b/features/objects.feature
@@ -37,7 +37,7 @@ Feature: Handles inlin / anonymous objects, i.e. those that are not defined in t
       }
     }
     """
-    When calling the method getTest with object "{ 'value':'test test'}"
+    When calling the method getTest with object {"value":"test test"}
     Then the requested URL should be https://example.com/api/v3/test?value=test%20test
 
   Scenario: Creates inline objects for request bodies
@@ -75,9 +75,9 @@ Feature: Handles inlin / anonymous objects, i.e. those that are not defined in t
       }
     }
     """
-    When calling the method testBody with object "{'value':'test'}"
+    When calling the method testBody with object {"value":"test"}
     Then the requested URL should be https://example.com/api/v3/test/testBody
-    And the request should have a body with value "{'value':'test'}"
+    And the request should have a body with value {"value":"test"}
   
   Scenario: Creates inline objects for responses
     Given an API with the following specification

--- a/features/pathparams.feature
+++ b/features/pathparams.feature
@@ -107,5 +107,5 @@ Feature: Path parameter handling
       }
     }
     """
-    When calling the method sendValueObject with object "{'id': 7, 'type': 'test'}"
+    When calling the method sendValueObject with object {"id": 7, "type": "test"}
     Then the requested URL should be https://example.com/api/v3/test/values/id,7,type,test

--- a/features/querystring.feature
+++ b/features/querystring.feature
@@ -233,5 +233,5 @@ Feature: Querystring handling
       }
     }
     """
-    When calling the method sendValueObject with object "{'id': 7, 'type': 'test'}"
+    When calling the method sendValueObject with object {"id": 7, "type": "test"}
     Then the requested URL should be https://example.com/api/v3/test/values?id=7&type=test

--- a/features/requestBody.feature
+++ b/features/requestBody.feature
@@ -40,6 +40,6 @@ Feature: Handles requests with a body
       }
     }
     """
-    When calling the method testBody with object "{'value':'test'}"
+    When calling the method testBody with object {"value":"test"}
     Then the requested URL should be https://example.com/api/v3/test/testBody
-    And the request should have a body with value "{'value':'test'}"
+    And the request should have a body with value {"value":"test"}


### PR DESCRIPTION
Single quotes are not valid!

Originally the outer quotes were used as part of the step definition regex. However, the nested quotes look quite confusing, and the regex doesn't really need them to locate the parameter 