### PR TITLE
Install generator dependencies when from GitHub

### DIFF
--- a/src/generate.js
+++ b/src/generate.js
@@ -83,7 +83,7 @@ async function generate(schemaPathOrUrl, generatorPathOrUrl, options) {
     log.standard(`Loading generator from '${generatorPathOrUrl}'`);
     let generatorPath;
     if (isUrl(generatorPathOrUrl)) {
-      generatorPath = generatorResolver.cloneGenerator(generatorPathOrUrl, false);
+      generatorPath = generatorResolver.cloneGenerator(generatorPathOrUrl, true);
     } else {
       //first check if there is a local generator
       generatorPath = path.resolve(generatorPathOrUrl);


### PR DESCRIPTION
NPM package Handlebars is needed when forging and therefore installing the dependencies is required when using a generator from GitHub.

PR for https://github.com/ScottLogic/openapi-forge/issues/70