### PR TITLE
test: fix the querystring character encoding

### DIFF
--- a/features/objects.feature
+++ b/features/objects.feature
@@ -38,7 +38,7 @@ Feature: Handles inlin / anonymous objects, i.e. those that are not defined in t
     }
     """
     When calling the method getTest with object {"value":"test test"}
-    Then the requested URL should be https://example.com/api/v3/test?value=test%20test
+    Then the requested URL should be https://example.com/api/v3/test?value=test+test
 
   Scenario: Creates inline objects for request bodies
     Given an API with the following specification


### PR DESCRIPTION
The `%20` encoding is used before the querystring, and `+` after. Because, why not?

ref: https://stackoverflow.com/a/1634293/249933