### PR TITLE
Fix failing scenario (encode commas in URL)

### DIFF
--- a/features/pathparams.feature
+++ b/features/pathparams.feature
@@ -108,4 +108,4 @@ Feature: Path parameter handling
     }
     """
     When calling the method sendValueObject with object {"id": 7, "type": "test"}
-    Then the requested URL should be https://example.com/api/v3/test/values/id,7,type,test
+    Then the requested URL should be https://example.com/api/v3/test/values/id%2C7%2Ctype%2Ctest


### PR DESCRIPTION
There was one more scenario that failed in the TypeScript generator. The commas needed encoding. A missed change from https://github.com/ScottLogic/openapi-forge/pull/75 which i also missed in the review