### PR TITLE
ci: use NPM packages when generating

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ Now you can forge your client API ...
 ```
 $ openapi-forge forge
  \ https://petstore3.swagger.io/api/v3/openapi.json
- \ https://github.com/ScottLogic/openapi-forge-typescript.git
+ \ openapi-forge-typescript
  \ -o api
 ```
 
-The above command forges a client API for the 'petstore' API, downloaded via the given URL. It uses the `openapi-forge-typescript` generator, which creates the TypeScript API, with the results saves in a folder called `api`.
+The above command forges a client API for the 'petstore' API, downloaded via the given URL creating a TypeScript API using the `openapi-forge-typescript` generator, with the results saves in a folder called `api`.
 
 If you take a look within the `api` folder you'll find that a number of files have been generated. The exact structure depends on the generator you use, with the detail available in the respective README file.
 
@@ -107,7 +107,7 @@ Options:
 
 **Generator Hierarchy**
 
-If a URL is given than it assumes that you are giving it a git repository. Otherwise it searches for a local generator folder and finally if no local generator is found it looks for an npm package and installs it if it does not exist.
+If a URL is given than it assumes that you are giving it a git repository. Otherwise it searches for a local generator folder at the same level as the forge with the same name of the generator and finally if no local generator is found it will look for an npm package and install it if it does not exist.
 
 ## Developer guide
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3525,6 +3525,7 @@
     },
     "node_modules/npm/node_modules/@colors/colors": {
       "version": "1.5.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -3534,16 +3535,19 @@
     },
     "node_modules/npm/node_modules/@gar/promisify": {
       "version": "1.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
       "version": "5.6.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3593,6 +3597,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/ci-detect": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -3601,6 +3606,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/config": {
       "version": "4.2.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3619,6 +3625,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/disparity-colors": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3630,6 +3637,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
       "version": "2.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3642,6 +3650,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/git": {
       "version": "3.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3661,6 +3670,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
       "version": "1.0.7",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3676,6 +3686,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents/node_modules/npm-bundled": {
       "version": "1.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3684,6 +3695,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
       "version": "2.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3698,6 +3710,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
       "version": "3.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3712,6 +3725,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/move-file": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3724,11 +3738,13 @@
     },
     "node_modules/npm/node_modules/@npmcli/name-from-folder": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/node-gyp": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -3737,6 +3753,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3748,6 +3765,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3759,6 +3777,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/query": {
       "version": "1.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3772,6 +3791,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
       "version": "4.2.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3787,6 +3807,7 @@
     },
     "node_modules/npm/node_modules/@tootallnate/once": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -3795,11 +3816,13 @@
     },
     "node_modules/npm/node_modules/abbrev": {
       "version": "1.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/agent-base": {
       "version": "6.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3811,6 +3834,7 @@
     },
     "node_modules/npm/node_modules/agentkeepalive": {
       "version": "4.2.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3824,6 +3848,7 @@
     },
     "node_modules/npm/node_modules/aggregate-error": {
       "version": "3.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3836,6 +3861,7 @@
     },
     "node_modules/npm/node_modules/ansi-regex": {
       "version": "5.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -3844,6 +3870,7 @@
     },
     "node_modules/npm/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3858,16 +3885,19 @@
     },
     "node_modules/npm/node_modules/aproba": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/archy": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/are-we-there-yet": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3880,16 +3910,19 @@
     },
     "node_modules/npm/node_modules/asap": {
       "version": "2.0.6",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/bin-links": {
       "version": "3.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3906,6 +3939,7 @@
     },
     "node_modules/npm/node_modules/bin-links/node_modules/npm-normalize-package-bin": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -3914,6 +3948,7 @@
     },
     "node_modules/npm/node_modules/binary-extensions": {
       "version": "2.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -3922,6 +3957,7 @@
     },
     "node_modules/npm/node_modules/brace-expansion": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3930,6 +3966,7 @@
     },
     "node_modules/npm/node_modules/builtins": {
       "version": "5.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3938,6 +3975,7 @@
     },
     "node_modules/npm/node_modules/cacache": {
       "version": "16.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3966,6 +4004,7 @@
     },
     "node_modules/npm/node_modules/chalk": {
       "version": "4.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3981,6 +4020,7 @@
     },
     "node_modules/npm/node_modules/chownr": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -3989,6 +4029,7 @@
     },
     "node_modules/npm/node_modules/cidr-regex": {
       "version": "3.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -4000,6 +4041,7 @@
     },
     "node_modules/npm/node_modules/clean-stack": {
       "version": "2.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4008,6 +4050,7 @@
     },
     "node_modules/npm/node_modules/cli-columns": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4020,6 +4063,7 @@
     },
     "node_modules/npm/node_modules/cli-table3": {
       "version": "0.6.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4034,6 +4078,7 @@
     },
     "node_modules/npm/node_modules/clone": {
       "version": "1.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4042,6 +4087,7 @@
     },
     "node_modules/npm/node_modules/cmd-shim": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4053,6 +4099,7 @@
     },
     "node_modules/npm/node_modules/color-convert": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4064,11 +4111,13 @@
     },
     "node_modules/npm/node_modules/color-name": {
       "version": "1.1.4",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/color-support": {
       "version": "1.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -4077,6 +4126,7 @@
     },
     "node_modules/npm/node_modules/columnify": {
       "version": "1.6.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4089,21 +4139,25 @@
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/concat-map": {
       "version": "0.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/console-control-strings": {
       "version": "1.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/cssesc": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -4115,6 +4169,7 @@
     },
     "node_modules/npm/node_modules/debug": {
       "version": "4.3.4",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4131,11 +4186,13 @@
     },
     "node_modules/npm/node_modules/debug/node_modules/ms": {
       "version": "2.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/debuglog": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4144,6 +4201,7 @@
     },
     "node_modules/npm/node_modules/defaults": {
       "version": "1.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4152,11 +4210,13 @@
     },
     "node_modules/npm/node_modules/delegates": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/depd": {
       "version": "1.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4165,6 +4225,7 @@
     },
     "node_modules/npm/node_modules/dezalgo": {
       "version": "1.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4174,6 +4235,7 @@
     },
     "node_modules/npm/node_modules/diff": {
       "version": "5.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -4182,11 +4244,13 @@
     },
     "node_modules/npm/node_modules/emoji-regex": {
       "version": "8.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/encoding": {
       "version": "0.1.13",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -4196,6 +4260,7 @@
     },
     "node_modules/npm/node_modules/env-paths": {
       "version": "2.2.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4204,16 +4269,19 @@
     },
     "node_modules/npm/node_modules/err-code": {
       "version": "2.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/fastest-levenshtein": {
       "version": "1.0.12",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/fs-minipass": {
       "version": "2.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4225,16 +4293,19 @@
     },
     "node_modules/npm/node_modules/fs.realpath": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/function-bind": {
       "version": "1.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/gauge": {
       "version": "4.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4253,6 +4324,7 @@
     },
     "node_modules/npm/node_modules/glob": {
       "version": "8.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4271,11 +4343,13 @@
     },
     "node_modules/npm/node_modules/graceful-fs": {
       "version": "4.2.10",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/has": {
       "version": "1.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4287,6 +4361,7 @@
     },
     "node_modules/npm/node_modules/has-flag": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4295,11 +4370,13 @@
     },
     "node_modules/npm/node_modules/has-unicode": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
       "version": "5.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4311,11 +4388,13 @@
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
       "version": "4.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4329,6 +4408,7 @@
     },
     "node_modules/npm/node_modules/https-proxy-agent": {
       "version": "5.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4341,6 +4421,7 @@
     },
     "node_modules/npm/node_modules/humanize-ms": {
       "version": "1.2.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4349,6 +4430,7 @@
     },
     "node_modules/npm/node_modules/iconv-lite": {
       "version": "0.6.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -4361,6 +4443,7 @@
     },
     "node_modules/npm/node_modules/ignore-walk": {
       "version": "5.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4372,6 +4455,7 @@
     },
     "node_modules/npm/node_modules/imurmurhash": {
       "version": "0.1.4",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4380,6 +4464,7 @@
     },
     "node_modules/npm/node_modules/indent-string": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4388,11 +4473,13 @@
     },
     "node_modules/npm/node_modules/infer-owner": {
       "version": "1.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/inflight": {
       "version": "1.0.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4402,11 +4489,13 @@
     },
     "node_modules/npm/node_modules/inherits": {
       "version": "2.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/ini": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -4415,6 +4504,7 @@
     },
     "node_modules/npm/node_modules/init-package-json": {
       "version": "3.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4432,11 +4522,13 @@
     },
     "node_modules/npm/node_modules/ip": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/ip-regex": {
       "version": "4.3.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4445,6 +4537,7 @@
     },
     "node_modules/npm/node_modules/is-cidr": {
       "version": "4.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -4456,6 +4549,7 @@
     },
     "node_modules/npm/node_modules/is-core-module": {
       "version": "2.10.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4467,6 +4561,7 @@
     },
     "node_modules/npm/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4475,21 +4570,25 @@
     },
     "node_modules/npm/node_modules/is-lambda": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/isexe": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/json-stringify-nice": {
       "version": "1.1.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -4498,6 +4597,7 @@
     },
     "node_modules/npm/node_modules/jsonparse": {
       "version": "1.3.1",
+      "dev": true,
       "engines": [
         "node >= 0.2.0"
       ],
@@ -4506,16 +4606,19 @@
     },
     "node_modules/npm/node_modules/just-diff": {
       "version": "5.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff-apply": {
       "version": "5.4.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
       "version": "6.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4530,6 +4633,7 @@
     },
     "node_modules/npm/node_modules/libnpmdiff": {
       "version": "4.0.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4548,6 +4652,7 @@
     },
     "node_modules/npm/node_modules/libnpmexec": {
       "version": "4.0.13",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4572,6 +4677,7 @@
     },
     "node_modules/npm/node_modules/libnpmfund": {
       "version": "3.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4583,6 +4689,7 @@
     },
     "node_modules/npm/node_modules/libnpmhook": {
       "version": "8.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4595,6 +4702,7 @@
     },
     "node_modules/npm/node_modules/libnpmorg": {
       "version": "4.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4607,6 +4715,7 @@
     },
     "node_modules/npm/node_modules/libnpmpack": {
       "version": "4.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4620,6 +4729,7 @@
     },
     "node_modules/npm/node_modules/libnpmpublish": {
       "version": "6.0.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4635,6 +4745,7 @@
     },
     "node_modules/npm/node_modules/libnpmsearch": {
       "version": "5.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4646,6 +4757,7 @@
     },
     "node_modules/npm/node_modules/libnpmteam": {
       "version": "4.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4658,6 +4770,7 @@
     },
     "node_modules/npm/node_modules/libnpmversion": {
       "version": "3.0.7",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4673,6 +4786,7 @@
     },
     "node_modules/npm/node_modules/lru-cache": {
       "version": "7.13.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -4681,6 +4795,7 @@
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
       "version": "10.2.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4707,6 +4822,7 @@
     },
     "node_modules/npm/node_modules/minimatch": {
       "version": "5.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4718,6 +4834,7 @@
     },
     "node_modules/npm/node_modules/minipass": {
       "version": "3.3.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4729,6 +4846,7 @@
     },
     "node_modules/npm/node_modules/minipass-collect": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4740,6 +4858,7 @@
     },
     "node_modules/npm/node_modules/minipass-fetch": {
       "version": "2.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4756,6 +4875,7 @@
     },
     "node_modules/npm/node_modules/minipass-flush": {
       "version": "1.0.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4767,6 +4887,7 @@
     },
     "node_modules/npm/node_modules/minipass-json-stream": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4776,6 +4897,7 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4787,6 +4909,7 @@
     },
     "node_modules/npm/node_modules/minipass-sized": {
       "version": "1.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4798,6 +4921,7 @@
     },
     "node_modules/npm/node_modules/minizlib": {
       "version": "2.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4810,6 +4934,7 @@
     },
     "node_modules/npm/node_modules/mkdirp": {
       "version": "1.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -4821,6 +4946,7 @@
     },
     "node_modules/npm/node_modules/mkdirp-infer-owner": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4834,16 +4960,19 @@
     },
     "node_modules/npm/node_modules/ms": {
       "version": "2.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/mute-stream": {
       "version": "0.0.8",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/negotiator": {
       "version": "0.6.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4852,6 +4981,7 @@
     },
     "node_modules/npm/node_modules/node-gyp": {
       "version": "9.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4875,6 +5005,7 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4884,6 +5015,7 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/glob": {
       "version": "7.2.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4903,6 +5035,7 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/minimatch": {
       "version": "3.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4914,6 +5047,7 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4928,6 +5062,7 @@
     },
     "node_modules/npm/node_modules/nopt": {
       "version": "6.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4942,6 +5077,7 @@
     },
     "node_modules/npm/node_modules/normalize-package-data": {
       "version": "4.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -4956,6 +5092,7 @@
     },
     "node_modules/npm/node_modules/npm-audit-report": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4967,6 +5104,7 @@
     },
     "node_modules/npm/node_modules/npm-bundled": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4978,6 +5116,7 @@
     },
     "node_modules/npm/node_modules/npm-bundled/node_modules/npm-normalize-package-bin": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -4986,6 +5125,7 @@
     },
     "node_modules/npm/node_modules/npm-install-checks": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -4997,11 +5137,13 @@
     },
     "node_modules/npm/node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/npm-package-arg": {
       "version": "9.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5016,6 +5158,7 @@
     },
     "node_modules/npm/node_modules/npm-packlist": {
       "version": "5.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5033,6 +5176,7 @@
     },
     "node_modules/npm/node_modules/npm-packlist/node_modules/npm-normalize-package-bin": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5041,6 +5185,7 @@
     },
     "node_modules/npm/node_modules/npm-pick-manifest": {
       "version": "7.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5055,6 +5200,7 @@
     },
     "node_modules/npm/node_modules/npm-pick-manifest/node_modules/npm-normalize-package-bin": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5063,6 +5209,7 @@
     },
     "node_modules/npm/node_modules/npm-profile": {
       "version": "6.2.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5075,6 +5222,7 @@
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
       "version": "13.3.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5092,11 +5240,13 @@
     },
     "node_modules/npm/node_modules/npm-user-validate": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/npmlog": {
       "version": "6.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5111,6 +5261,7 @@
     },
     "node_modules/npm/node_modules/once": {
       "version": "1.4.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5119,6 +5270,7 @@
     },
     "node_modules/npm/node_modules/opener": {
       "version": "1.5.2",
+      "dev": true,
       "inBundle": true,
       "license": "(WTFPL OR MIT)",
       "bin": {
@@ -5127,6 +5279,7 @@
     },
     "node_modules/npm/node_modules/p-map": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5141,6 +5294,7 @@
     },
     "node_modules/npm/node_modules/pacote": {
       "version": "13.6.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5175,6 +5329,7 @@
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
       "version": "2.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5188,6 +5343,7 @@
     },
     "node_modules/npm/node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5196,6 +5352,7 @@
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
       "version": "6.0.10",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5208,6 +5365,7 @@
     },
     "node_modules/npm/node_modules/proc-log": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5216,6 +5374,7 @@
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -5224,6 +5383,7 @@
     },
     "node_modules/npm/node_modules/promise-call-limit": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -5232,11 +5392,13 @@
     },
     "node_modules/npm/node_modules/promise-inflight": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/promise-retry": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5249,6 +5411,7 @@
     },
     "node_modules/npm/node_modules/promzard": {
       "version": "0.3.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5257,6 +5420,7 @@
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
       "version": "0.12.0",
+      "dev": true,
       "inBundle": true,
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
@@ -5264,6 +5428,7 @@
     },
     "node_modules/npm/node_modules/read": {
       "version": "1.0.7",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5275,6 +5440,7 @@
     },
     "node_modules/npm/node_modules/read-cmd-shim": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5283,6 +5449,7 @@
     },
     "node_modules/npm/node_modules/read-package-json": {
       "version": "5.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5297,6 +5464,7 @@
     },
     "node_modules/npm/node_modules/read-package-json-fast": {
       "version": "2.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5309,6 +5477,7 @@
     },
     "node_modules/npm/node_modules/read-package-json/node_modules/npm-normalize-package-bin": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5317,6 +5486,7 @@
     },
     "node_modules/npm/node_modules/readable-stream": {
       "version": "3.6.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5330,6 +5500,7 @@
     },
     "node_modules/npm/node_modules/readdir-scoped-modules": {
       "version": "1.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5341,6 +5512,7 @@
     },
     "node_modules/npm/node_modules/retry": {
       "version": "0.12.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5349,6 +5521,7 @@
     },
     "node_modules/npm/node_modules/rimraf": {
       "version": "3.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5363,6 +5536,7 @@
     },
     "node_modules/npm/node_modules/rimraf/node_modules/brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5372,6 +5546,7 @@
     },
     "node_modules/npm/node_modules/rimraf/node_modules/glob": {
       "version": "7.2.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5391,6 +5566,7 @@
     },
     "node_modules/npm/node_modules/rimraf/node_modules/minimatch": {
       "version": "3.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5402,6 +5578,7 @@
     },
     "node_modules/npm/node_modules/safe-buffer": {
       "version": "5.2.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5421,12 +5598,14 @@
     },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
       "version": "7.3.7",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5441,6 +5620,7 @@
     },
     "node_modules/npm/node_modules/semver/node_modules/lru-cache": {
       "version": "6.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5452,16 +5632,19 @@
     },
     "node_modules/npm/node_modules/set-blocking": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/signal-exit": {
       "version": "3.0.7",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/smart-buffer": {
       "version": "4.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5471,6 +5654,7 @@
     },
     "node_modules/npm/node_modules/socks": {
       "version": "2.7.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5484,6 +5668,7 @@
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
       "version": "7.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5497,6 +5682,7 @@
     },
     "node_modules/npm/node_modules/spdx-correct": {
       "version": "3.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5506,11 +5692,13 @@
     },
     "node_modules/npm/node_modules/spdx-exceptions": {
       "version": "2.3.0",
+      "dev": true,
       "inBundle": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/npm/node_modules/spdx-expression-parse": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5520,11 +5708,13 @@
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
       "version": "3.0.11",
+      "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
     },
     "node_modules/npm/node_modules/ssri": {
       "version": "9.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5536,6 +5726,7 @@
     },
     "node_modules/npm/node_modules/string_decoder": {
       "version": "1.3.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5544,6 +5735,7 @@
     },
     "node_modules/npm/node_modules/string-width": {
       "version": "4.2.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5557,6 +5749,7 @@
     },
     "node_modules/npm/node_modules/strip-ansi": {
       "version": "6.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5568,6 +5761,7 @@
     },
     "node_modules/npm/node_modules/supports-color": {
       "version": "7.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5579,6 +5773,7 @@
     },
     "node_modules/npm/node_modules/tar": {
       "version": "6.1.11",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5595,16 +5790,19 @@
     },
     "node_modules/npm/node_modules/text-table": {
       "version": "0.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tiny-relative-date": {
       "version": "1.3.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/treeverse": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5613,6 +5811,7 @@
     },
     "node_modules/npm/node_modules/unique-filename": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5624,6 +5823,7 @@
     },
     "node_modules/npm/node_modules/unique-slug": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5635,11 +5835,13 @@
     },
     "node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5649,6 +5851,7 @@
     },
     "node_modules/npm/node_modules/validate-npm-package-name": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5660,11 +5863,13 @@
     },
     "node_modules/npm/node_modules/walk-up-path": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/wcwidth": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5673,6 +5878,7 @@
     },
     "node_modules/npm/node_modules/which": {
       "version": "2.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5687,6 +5893,7 @@
     },
     "node_modules/npm/node_modules/wide-align": {
       "version": "1.1.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5695,11 +5902,13 @@
     },
     "node_modules/npm/node_modules/wrappy": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/write-file-atomic": {
       "version": "4.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5712,6 +5921,7 @@
     },
     "node_modules/npm/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
@@ -9838,19 +10048,23 @@
         "@colors/colors": {
           "version": "1.5.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "@gar/promisify": {
           "version": "1.1.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "@isaacs/string-locale-compare": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "@npmcli/arborist": {
           "version": "5.6.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "@isaacs/string-locale-compare": "^1.1.0",
             "@npmcli/installed-package-contents": "^1.0.7",
@@ -9892,11 +10106,13 @@
         },
         "@npmcli/ci-detect": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "@npmcli/config": {
           "version": "4.2.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "@npmcli/map-workspaces": "^2.0.2",
             "ini": "^3.0.0",
@@ -9911,6 +10127,7 @@
         "@npmcli/disparity-colors": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.3.0"
           }
@@ -9918,6 +10135,7 @@
         "@npmcli/fs": {
           "version": "2.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "@gar/promisify": "^1.1.3",
             "semver": "^7.3.5"
@@ -9926,6 +10144,7 @@
         "@npmcli/git": {
           "version": "3.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "@npmcli/promise-spawn": "^3.0.0",
             "lru-cache": "^7.4.4",
@@ -9941,6 +10160,7 @@
         "@npmcli/installed-package-contents": {
           "version": "1.0.7",
           "bundled": true,
+          "dev": true,
           "requires": {
             "npm-bundled": "^1.1.1",
             "npm-normalize-package-bin": "^1.0.1"
@@ -9949,6 +10169,7 @@
             "npm-bundled": {
               "version": "1.1.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "npm-normalize-package-bin": "^1.0.1"
               }
@@ -9958,6 +10179,7 @@
         "@npmcli/map-workspaces": {
           "version": "2.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "@npmcli/name-from-folder": "^1.0.1",
             "glob": "^8.0.1",
@@ -9968,6 +10190,7 @@
         "@npmcli/metavuln-calculator": {
           "version": "3.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "cacache": "^16.0.0",
             "json-parse-even-better-errors": "^2.3.1",
@@ -9978,6 +10201,7 @@
         "@npmcli/move-file": {
           "version": "2.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "mkdirp": "^1.0.4",
             "rimraf": "^3.0.2"
@@ -9985,15 +10209,18 @@
         },
         "@npmcli/name-from-folder": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "@npmcli/node-gyp": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "@npmcli/package-json": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "json-parse-even-better-errors": "^2.3.1"
           }
@@ -10001,6 +10228,7 @@
         "@npmcli/promise-spawn": {
           "version": "3.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "infer-owner": "^1.0.4"
           }
@@ -10008,6 +10236,7 @@
         "@npmcli/query": {
           "version": "1.2.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "npm-package-arg": "^9.1.0",
             "postcss-selector-parser": "^6.0.10",
@@ -10017,6 +10246,7 @@
         "@npmcli/run-script": {
           "version": "4.2.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "@npmcli/node-gyp": "^2.0.0",
             "@npmcli/promise-spawn": "^3.0.0",
@@ -10027,15 +10257,18 @@
         },
         "@tootallnate/once": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "agent-base": {
           "version": "6.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "debug": "4"
           }
@@ -10043,6 +10276,7 @@
         "agentkeepalive": {
           "version": "4.2.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "debug": "^4.1.0",
             "depd": "^1.1.2",
@@ -10052,6 +10286,7 @@
         "aggregate-error": {
           "version": "3.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "clean-stack": "^2.0.0",
             "indent-string": "^4.0.0"
@@ -10059,26 +10294,31 @@
         },
         "ansi-regex": {
           "version": "5.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ansi-styles": {
           "version": "4.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
         "aproba": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "archy": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "are-we-there-yet": {
           "version": "3.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^3.6.0"
@@ -10086,15 +10326,18 @@
         },
         "asap": {
           "version": "2.0.6",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "balanced-match": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "bin-links": {
           "version": "3.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "cmd-shim": "^5.0.0",
             "mkdirp-infer-owner": "^2.0.0",
@@ -10106,17 +10349,20 @@
           "dependencies": {
             "npm-normalize-package-bin": {
               "version": "2.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "binary-extensions": {
           "version": "2.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "brace-expansion": {
           "version": "2.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "balanced-match": "^1.0.0"
           }
@@ -10124,6 +10370,7 @@
         "builtins": {
           "version": "5.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "semver": "^7.0.0"
           }
@@ -10131,6 +10378,7 @@
         "cacache": {
           "version": "16.1.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "@npmcli/fs": "^2.1.0",
             "@npmcli/move-file": "^2.0.0",
@@ -10155,6 +10403,7 @@
         "chalk": {
           "version": "4.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -10162,22 +10411,26 @@
         },
         "chownr": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "cidr-regex": {
           "version": "3.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ip-regex": "^4.1.0"
           }
         },
         "clean-stack": {
           "version": "2.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "cli-columns": {
           "version": "4.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "string-width": "^4.2.3",
             "strip-ansi": "^6.0.1"
@@ -10186,6 +10439,7 @@
         "cli-table3": {
           "version": "0.6.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "@colors/colors": "1.5.0",
             "string-width": "^4.2.0"
@@ -10193,11 +10447,13 @@
         },
         "clone": {
           "version": "1.0.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "cmd-shim": {
           "version": "5.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "mkdirp-infer-owner": "^2.0.0"
           }
@@ -10205,21 +10461,25 @@
         "color-convert": {
           "version": "2.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
         },
         "color-name": {
           "version": "1.1.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "color-support": {
           "version": "1.1.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "columnify": {
           "version": "1.6.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "strip-ansi": "^6.0.1",
             "wcwidth": "^1.0.0"
@@ -10227,55 +10487,66 @@
         },
         "common-ancestor-path": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "cssesc": {
           "version": "3.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "debug": {
           "version": "4.3.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ms": "2.1.2"
           },
           "dependencies": {
             "ms": {
               "version": "2.1.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "debuglog": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "defaults": {
           "version": "1.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "clone": "^1.0.2"
           }
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "depd": {
           "version": "1.1.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "dezalgo": {
           "version": "1.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "asap": "^2.0.0",
             "wrappy": "1"
@@ -10283,15 +10554,18 @@
         },
         "diff": {
           "version": "5.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "emoji-regex": {
           "version": "8.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "encoding": {
           "version": "0.1.13",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "iconv-lite": "^0.6.2"
@@ -10299,34 +10573,41 @@
         },
         "env-paths": {
           "version": "2.2.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "err-code": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "fastest-levenshtein": {
           "version": "1.0.12",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "fs-minipass": {
           "version": "2.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "minipass": "^3.0.0"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "function-bind": {
           "version": "1.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "gauge": {
           "version": "4.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aproba": "^1.0.3 || ^2.0.0",
             "color-support": "^1.1.3",
@@ -10341,6 +10622,7 @@
         "glob": {
           "version": "8.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -10351,37 +10633,44 @@
         },
         "graceful-fs": {
           "version": "4.2.10",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "has": {
           "version": "1.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "function-bind": "^1.1.1"
           }
         },
         "has-flag": {
           "version": "4.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "hosted-git-info": {
           "version": "5.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "lru-cache": "^7.5.1"
           }
         },
         "http-cache-semantics": {
           "version": "4.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "http-proxy-agent": {
           "version": "5.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "@tootallnate/once": "2",
             "agent-base": "6",
@@ -10391,6 +10680,7 @@
         "https-proxy-agent": {
           "version": "5.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "agent-base": "6",
             "debug": "4"
@@ -10399,6 +10689,7 @@
         "humanize-ms": {
           "version": "1.2.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ms": "^2.0.0"
           }
@@ -10406,6 +10697,7 @@
         "iconv-lite": {
           "version": "0.6.3",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -10414,25 +10706,30 @@
         "ignore-walk": {
           "version": "5.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "minimatch": "^5.0.1"
           }
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "indent-string": {
           "version": "4.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "infer-owner": {
           "version": "1.0.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
+          "dev": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -10440,15 +10737,18 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ini": {
           "version": "3.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "init-package-json": {
           "version": "3.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "npm-package-arg": "^9.0.1",
             "promzard": "^0.3.0",
@@ -10461,15 +10761,18 @@
         },
         "ip": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ip-regex": {
           "version": "4.3.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-cidr": {
           "version": "4.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "cidr-regex": "^3.1.1"
           }
@@ -10477,45 +10780,55 @@
         "is-core-module": {
           "version": "2.10.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "has": "^1.0.3"
           }
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-lambda": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "json-parse-even-better-errors": {
           "version": "2.3.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "json-stringify-nice": {
           "version": "1.1.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "jsonparse": {
           "version": "1.3.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "just-diff": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "just-diff-apply": {
           "version": "5.4.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "libnpmaccess": {
           "version": "6.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aproba": "^2.0.0",
             "minipass": "^3.1.1",
@@ -10526,6 +10839,7 @@
         "libnpmdiff": {
           "version": "4.0.5",
           "bundled": true,
+          "dev": true,
           "requires": {
             "@npmcli/disparity-colors": "^2.0.0",
             "@npmcli/installed-package-contents": "^1.0.7",
@@ -10540,6 +10854,7 @@
         "libnpmexec": {
           "version": "4.0.13",
           "bundled": true,
+          "dev": true,
           "requires": {
             "@npmcli/arborist": "^5.6.2",
             "@npmcli/ci-detect": "^2.0.0",
@@ -10560,6 +10875,7 @@
         "libnpmfund": {
           "version": "3.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "@npmcli/arborist": "^5.6.2"
           }
@@ -10567,6 +10883,7 @@
         "libnpmhook": {
           "version": "8.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aproba": "^2.0.0",
             "npm-registry-fetch": "^13.0.0"
@@ -10575,6 +10892,7 @@
         "libnpmorg": {
           "version": "4.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aproba": "^2.0.0",
             "npm-registry-fetch": "^13.0.0"
@@ -10583,6 +10901,7 @@
         "libnpmpack": {
           "version": "4.1.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "@npmcli/run-script": "^4.1.3",
             "npm-package-arg": "^9.0.1",
@@ -10592,6 +10911,7 @@
         "libnpmpublish": {
           "version": "6.0.5",
           "bundled": true,
+          "dev": true,
           "requires": {
             "normalize-package-data": "^4.0.0",
             "npm-package-arg": "^9.0.1",
@@ -10603,6 +10923,7 @@
         "libnpmsearch": {
           "version": "5.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "npm-registry-fetch": "^13.0.0"
           }
@@ -10610,6 +10931,7 @@
         "libnpmteam": {
           "version": "4.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aproba": "^2.0.0",
             "npm-registry-fetch": "^13.0.0"
@@ -10618,6 +10940,7 @@
         "libnpmversion": {
           "version": "3.0.7",
           "bundled": true,
+          "dev": true,
           "requires": {
             "@npmcli/git": "^3.0.0",
             "@npmcli/run-script": "^4.1.3",
@@ -10628,11 +10951,13 @@
         },
         "lru-cache": {
           "version": "7.13.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "make-fetch-happen": {
           "version": "10.2.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "agentkeepalive": "^4.2.1",
             "cacache": "^16.1.0",
@@ -10655,6 +10980,7 @@
         "minimatch": {
           "version": "5.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
           }
@@ -10662,6 +10988,7 @@
         "minipass": {
           "version": "3.3.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -10669,6 +10996,7 @@
         "minipass-collect": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "minipass": "^3.0.0"
           }
@@ -10676,6 +11004,7 @@
         "minipass-fetch": {
           "version": "2.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "encoding": "^0.1.13",
             "minipass": "^3.1.6",
@@ -10686,6 +11015,7 @@
         "minipass-flush": {
           "version": "1.0.5",
           "bundled": true,
+          "dev": true,
           "requires": {
             "minipass": "^3.0.0"
           }
@@ -10693,6 +11023,7 @@
         "minipass-json-stream": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "jsonparse": "^1.3.1",
             "minipass": "^3.0.0"
@@ -10701,6 +11032,7 @@
         "minipass-pipeline": {
           "version": "1.2.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "minipass": "^3.0.0"
           }
@@ -10708,6 +11040,7 @@
         "minipass-sized": {
           "version": "1.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "minipass": "^3.0.0"
           }
@@ -10715,6 +11048,7 @@
         "minizlib": {
           "version": "2.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "minipass": "^3.0.0",
             "yallist": "^4.0.0"
@@ -10722,11 +11056,13 @@
         },
         "mkdirp": {
           "version": "1.0.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "mkdirp-infer-owner": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "chownr": "^2.0.0",
             "infer-owner": "^1.0.4",
@@ -10735,19 +11071,23 @@
         },
         "ms": {
           "version": "2.1.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "mute-stream": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "negotiator": {
           "version": "0.6.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "node-gyp": {
           "version": "9.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "env-paths": "^2.2.0",
             "glob": "^7.1.4",
@@ -10764,6 +11104,7 @@
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -10772,6 +11113,7 @@
             "glob": {
               "version": "7.2.3",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -10784,6 +11126,7 @@
             "minimatch": {
               "version": "3.1.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -10791,6 +11134,7 @@
             "nopt": {
               "version": "5.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "abbrev": "1"
               }
@@ -10800,6 +11144,7 @@
         "nopt": {
           "version": "6.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "abbrev": "^1.0.0"
           }
@@ -10807,6 +11152,7 @@
         "normalize-package-data": {
           "version": "4.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "hosted-git-info": "^5.0.0",
             "is-core-module": "^2.8.1",
@@ -10817,6 +11163,7 @@
         "npm-audit-report": {
           "version": "3.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "chalk": "^4.0.0"
           }
@@ -10824,30 +11171,35 @@
         "npm-bundled": {
           "version": "2.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "npm-normalize-package-bin": "^2.0.0"
           },
           "dependencies": {
             "npm-normalize-package-bin": {
               "version": "2.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "npm-install-checks": {
           "version": "5.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "semver": "^7.1.1"
           }
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "npm-package-arg": {
           "version": "9.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "hosted-git-info": "^5.0.0",
             "proc-log": "^2.0.1",
@@ -10858,6 +11210,7 @@
         "npm-packlist": {
           "version": "5.1.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "glob": "^8.0.1",
             "ignore-walk": "^5.0.1",
@@ -10867,13 +11220,15 @@
           "dependencies": {
             "npm-normalize-package-bin": {
               "version": "2.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "npm-pick-manifest": {
           "version": "7.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "npm-install-checks": "^5.0.0",
             "npm-normalize-package-bin": "^2.0.0",
@@ -10883,13 +11238,15 @@
           "dependencies": {
             "npm-normalize-package-bin": {
               "version": "2.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "npm-profile": {
           "version": "6.2.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "npm-registry-fetch": "^13.0.1",
             "proc-log": "^2.0.0"
@@ -10898,6 +11255,7 @@
         "npm-registry-fetch": {
           "version": "13.3.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "make-fetch-happen": "^10.0.6",
             "minipass": "^3.1.6",
@@ -10910,11 +11268,13 @@
         },
         "npm-user-validate": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "npmlog": {
           "version": "6.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "are-we-there-yet": "^3.0.0",
             "console-control-strings": "^1.1.0",
@@ -10925,17 +11285,20 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "wrappy": "1"
           }
         },
         "opener": {
           "version": "1.5.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "p-map": {
           "version": "4.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aggregate-error": "^3.0.0"
           }
@@ -10943,6 +11306,7 @@
         "pacote": {
           "version": "13.6.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "@npmcli/git": "^3.0.0",
             "@npmcli/installed-package-contents": "^1.0.7",
@@ -10970,6 +11334,7 @@
         "parse-conflict-json": {
           "version": "2.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "json-parse-even-better-errors": "^2.3.1",
             "just-diff": "^5.0.1",
@@ -10978,11 +11343,13 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "postcss-selector-parser": {
           "version": "6.0.10",
           "bundled": true,
+          "dev": true,
           "requires": {
             "cssesc": "^3.0.0",
             "util-deprecate": "^1.0.2"
@@ -10990,23 +11357,28 @@
         },
         "proc-log": {
           "version": "2.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "promise-all-reject-late": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "promise-call-limit": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "promise-inflight": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "promise-retry": {
           "version": "2.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "err-code": "^2.0.2",
             "retry": "^0.12.0"
@@ -11015,28 +11387,33 @@
         "promzard": {
           "version": "0.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "read": "1"
           }
         },
         "qrcode-terminal": {
           "version": "0.12.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "read": {
           "version": "1.0.7",
           "bundled": true,
+          "dev": true,
           "requires": {
             "mute-stream": "~0.0.4"
           }
         },
         "read-cmd-shim": {
           "version": "3.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "read-package-json": {
           "version": "5.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "glob": "^8.0.1",
             "json-parse-even-better-errors": "^2.3.1",
@@ -11046,13 +11423,15 @@
           "dependencies": {
             "npm-normalize-package-bin": {
               "version": "2.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "read-package-json-fast": {
           "version": "2.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "json-parse-even-better-errors": "^2.3.0",
             "npm-normalize-package-bin": "^1.0.1"
@@ -11061,6 +11440,7 @@
         "readable-stream": {
           "version": "3.6.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -11070,6 +11450,7 @@
         "readdir-scoped-modules": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "debuglog": "^1.0.1",
             "dezalgo": "^1.0.0",
@@ -11079,11 +11460,13 @@
         },
         "retry": {
           "version": "0.12.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "rimraf": {
           "version": "3.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "glob": "^7.1.3"
           },
@@ -11091,6 +11474,7 @@
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -11099,6 +11483,7 @@
             "glob": {
               "version": "7.2.3",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -11111,6 +11496,7 @@
             "minimatch": {
               "version": "3.1.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -11119,16 +11505,19 @@
         },
         "safe-buffer": {
           "version": "5.2.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "semver": {
           "version": "7.3.7",
           "bundled": true,
+          "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           },
@@ -11136,6 +11525,7 @@
             "lru-cache": {
               "version": "6.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "yallist": "^4.0.0"
               }
@@ -11144,19 +11534,23 @@
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "signal-exit": {
           "version": "3.0.7",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "smart-buffer": {
           "version": "4.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "socks": {
           "version": "2.7.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ip": "^2.0.0",
             "smart-buffer": "^4.2.0"
@@ -11165,6 +11559,7 @@
         "socks-proxy-agent": {
           "version": "7.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "agent-base": "^6.0.2",
             "debug": "^4.3.3",
@@ -11174,6 +11569,7 @@
         "spdx-correct": {
           "version": "3.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "spdx-expression-parse": "^3.0.0",
             "spdx-license-ids": "^3.0.0"
@@ -11181,11 +11577,13 @@
         },
         "spdx-exceptions": {
           "version": "2.3.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "spdx-expression-parse": {
           "version": "3.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "spdx-exceptions": "^2.1.0",
             "spdx-license-ids": "^3.0.0"
@@ -11193,11 +11591,13 @@
         },
         "spdx-license-ids": {
           "version": "3.0.11",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ssri": {
           "version": "9.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "minipass": "^3.1.1"
           }
@@ -11205,6 +11605,7 @@
         "string_decoder": {
           "version": "1.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "safe-buffer": "~5.2.0"
           }
@@ -11212,6 +11613,7 @@
         "string-width": {
           "version": "4.2.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -11221,6 +11623,7 @@
         "strip-ansi": {
           "version": "6.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ansi-regex": "^5.0.1"
           }
@@ -11228,6 +11631,7 @@
         "supports-color": {
           "version": "7.2.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -11235,6 +11639,7 @@
         "tar": {
           "version": "6.1.11",
           "bundled": true,
+          "dev": true,
           "requires": {
             "chownr": "^2.0.0",
             "fs-minipass": "^2.0.0",
@@ -11246,19 +11651,23 @@
         },
         "text-table": {
           "version": "0.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "tiny-relative-date": {
           "version": "1.3.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "treeverse": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "unique-filename": {
           "version": "2.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "unique-slug": "^3.0.0"
           }
@@ -11266,17 +11675,20 @@
         "unique-slug": {
           "version": "3.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "imurmurhash": "^0.1.4"
           }
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "validate-npm-package-license": {
           "version": "3.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "spdx-correct": "^3.0.0",
             "spdx-expression-parse": "^3.0.0"
@@ -11285,17 +11697,20 @@
         "validate-npm-package-name": {
           "version": "4.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "builtins": "^5.0.0"
           }
         },
         "walk-up-path": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "wcwidth": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "defaults": "^1.0.3"
           }
@@ -11303,6 +11718,7 @@
         "which": {
           "version": "2.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -11310,17 +11726,20 @@
         "wide-align": {
           "version": "1.1.5",
           "bundled": true,
+          "dev": true,
           "requires": {
             "string-width": "^1.0.2 || 2 || 3 || 4"
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "write-file-atomic": {
           "version": "4.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "imurmurhash": "^0.1.4",
             "signal-exit": "^3.0.7"
@@ -11328,7 +11747,8 @@
         },
         "yallist": {
           "version": "4.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         }
       }
     },

--- a/src/testGenerators.js
+++ b/src/testGenerators.js
@@ -45,20 +45,8 @@ function getGenerator(languageData, generatorOption) {
   if (!fs.existsSync(generatorPath)) {
     log.verbose(`Cannot find ${languageData.languageString} generator`);
 
-    if (
-      process.argv.includes(`-${languageData.languageLetter}`) ||
-      process.argv.includes(`--${languageData.languageString.toLowerCase()}`)
-    ) {
-      throw new Error(
-        `No local ${languageData.languageString} generator found at ${generatorPath}.`
-      );
-    }
-
     // Local generator does not exist, clone from GitHub to temporary location
-    generatorPath = generatorResolver.cloneGenerator(
-      languageData.generatorURL,
-      true
-    );
+    generatorPath = generatorResolver.getGenerator(languageData.generatorURL);
   }
   return generatorPath;
 }


### PR DESCRIPTION
PR for issue: https://github.com/ScottLogic/openapi-forge/issues/53

- NPM packages only used when generating. 
- Add missing husky install script
- Misc refactoring of generator retrieval.
- Update README.md

Side Notes
- When testing the repo is cloned. This is due to the TypeScript testing not finding some 'required'. I have a suspicion that this is due to the nesting of npm modules and cucumber-js resolving relative/partial file paths incorrectly (to the wrong level of npm module.  I copied the typescript generator module out of the forge and the tests started working without changing anything.
- There are no versioning problems as it always clone the most recent commit to main when testing.

