### PR TITLE
feat: add version number to commander

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,13 @@
 
 const { Command } = require("commander");
 const generate = require("./generate");
+var packageJson = require("../package.json");
 const testGenerators = require("./testGenerators");
 const program = new Command();
 
 program.name("openapi-forge");
+
+program.version(packageJson.version);
 
 program
   .command("forge")


### PR DESCRIPTION
add `--version` option using the package.json which is auto-updated by semantic-release in CI/CD. 

This is best way because if `version` doesn't exist in package.json, then it just states `error: unknown option '--version'` which is the current behaviour and also prevents the need for a regex replace in the CI/CD release pipeline