### PR TITLE
fix: make path creation platform agnostic

### DIFF
--- a/src/generatorResolver.js
+++ b/src/generatorResolver.js
@@ -78,7 +78,7 @@ function installGeneratorFromNPM(generatorPathOrUrl) {
   }
   const generatorPath = path.resolve(
     __dirname,
-    `..\\node_modules\\${generatorPathOrUrl}`
+    path.join("..", "node_modules", generatorPathOrUrl)
   );
   shell.cd(generatorPath, log.shellOptions);
   installGeneratorDependencies();


### PR DESCRIPTION
closes: #132 

using path creation form path module to make path generation platform agnostic.

@ColinEberhardt can you please test this on mac to see if it works.