### PR TITLE
test: simplify the generator tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,6 @@ jobs:
     runs-on: windows-latest 
 
     steps:
-      - name: Check out Git repository
-        uses: actions/checkout@v3
-
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
@@ -24,45 +21,58 @@ jobs:
       - name: Set npm shell
         run: npm config set script-shell "C:\\Program Files\\Git\\bin\\bash.exe"
 
-      - name: Install Node.js dependencies globally
+      - name: Check out openapi-forge repository
+        uses: actions/checkout@v3
+        with: 
+          path: openapi-forge
+
+      - name: Install openapi-forge dependencies globally
         run: |
+          cd openapi-forge
           npm install
           npm install --global
 
+      - name: Check out the openapi-forge-javascript generator
+        uses: actions/checkout@v3
+        with: 
+          repository: ScottLogic/openapi-forge-javascript
+          path: openapi-forge-javascript
+
+      - name: Install openapi-forge-javascript dependencies
+        run: |
+          cd openapi-forge-javascript
+          npm install
+
+      - name: Check out the openapi-forge-csharp generator
+        uses: actions/checkout@v3
+        with: 
+          repository: ScottLogic/openapi-forge-csharp
+          path: openapi-forge-csharp
+
+      - name: Install openapi-forge-csharp dependencies
+        run: |
+          cd openapi-forge-csharp
+          npm install
+
+      - name: Check out the openapi-forge-typescript generator
+        uses: actions/checkout@v3
+        with: 
+          repository: ScottLogic/openapi-forge-typescript
+          path: openapi-forge-typescript
+
+      - name: Install openapi-forge-typescript dependencies
+        run: |
+          cd openapi-forge-typescript
+          npm install
+
       - name: Test generators
-        run: npm run test:generators
+        run: |
+          cd openapi-forge
+          openapi-forge test-generators --format json --generators openapi-forge-javascript openapi-forge-typescript openapi-forge-csharp > test-results.json
         continue-on-error: true
 
       - name: Upload test results
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: test-results.json
-
-      - name: Download previous test results
-        id: download-artifact
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          workflow: test.yml
-          branch: master
-          name: test-results
-          path: CICD_${{github.sha}}
-          workflow_conclusion: completed
-
-      - name: Compare test results
-        run: node CICD/compareTestResults test-results.json CICD_${{github.sha}}/test-results.json
-        continue-on-error: true
-
-      - name: Update webpage contents
-        if: github.event_name == 'push'
-        run: |
-          git config --global user.name 'GitHubActions'
-          git config --global user.email '<>'
-          git checkout -b gh-pages
-          git reset --hard master
-          node CICD/updateWebpage test-results.json 
-          npm run format:write:all
-          git add docs/
-          git commit -m "docs: auto-update docs/"
-          git push --force --set-upstream origin gh-pages
-
+          path: openapi-forge/test-results.json

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/generate.js",
   "scripts": {
     "prepare": "husky install",
-    "test:generators": "openapi-forge test-generators -l v -o",
+    "test:generators": "openapi-forge test-generators",
     "format:check:all": "prettier --check .",
     "format:write:all": "prettier --write .",
     "lint:check:all": "eslint .",

--- a/src/index.js
+++ b/src/index.js
@@ -44,28 +44,13 @@ program
   .command("test-generators")
   .description("Test language specific generators.")
   .option(
-    "-g, --generators <gens>",
-    "Narrow down the generators to test. Each letter is a generator, combine letters to test multiple generators, options are: c (CSharp), t (TypeScript)", //h (PHP), p (Python), j (Java), s (JavaScript)
-    "ct"
-  )
-  .option(
-    "-c, --csharp <csharpPath>",
-    "Sets the location of the CSharp generator. Default is a directory named 'openapi-forge-csharp' in the same location as openapi-forge",
-    "./openapi-forge-csharp"
-  )
-  .option(
-    "-t, --typescript <typescriptPath>",
-    "Sets the location of the TypeScript generator. Default is a directory named 'openapi-forge-typescript' in the same location as openapi-forge",
-    "./openapi-forge-typescript"
+    "-g, --generators <gens...>",
+    "Generators to test, e.g. openapi-forge-typescript"
   )
   .option(
     "-l, --logLevel <level>",
     "Sets the logging level, options are: quiet ('quiet', 'q' or '0'), standard (default) ('standard', 's' or '1'), verbose ('verbose', 'v' or '2')",
     "1"
-  )
-  .option(
-    "-o, --outputFile [file]",
-    `Writes the testing results to a JSON file, defaults to "${testGenerators.defaultResultFile}"`
   )
   .action(async (options) => {
     testGenerators.testGenerators(options);

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 #! /usr/bin/env node
 
-const { Command } = require("commander");
+const { Command, Option } = require("commander");
 const generate = require("./generate");
 const packageJson = require("../package.json");
 const testGenerators = require("./testGenerators");
@@ -51,6 +51,11 @@ program
     "-l, --logLevel <level>",
     "Sets the logging level, options are: quiet ('quiet', 'q' or '0'), standard (default) ('standard', 's' or '1'), verbose ('verbose', 'v' or '2')",
     "1"
+  )
+  .addOption(
+    new Option("-f, --format <format>", "Output format")
+      .choices(["table", "json"])
+      .default("table")
   )
   .action(async (options) => {
     testGenerators.testGenerators(options);

--- a/src/testGenerators.js
+++ b/src/testGenerators.js
@@ -70,7 +70,11 @@ function testGenerators(options) {
     }
   });
 
-  console.table(aggregatedResults);
+  if (options.format === "table") {
+    console.table(aggregatedResults);
+  } else {
+    console.log(JSON.stringify(aggregatedResults, null, 2));
+  }
 }
 
 module.exports = {

--- a/src/testGenerators.js
+++ b/src/testGenerators.js
@@ -1,178 +1,78 @@
-//TODO: Once generators are published to npm use package instead of github repo. command 'npm install {packageName} -g --prefix {packageInstallLocation}' and then remember to uninstall at the end of testing generator.
-
-const fs = require("fs");
 const path = require("path");
 const shell = require("shelljs");
 
 const log = require("./log");
-const generatorResolver = require("./generatorResolver");
 
-const defaultResultFile = "test-results.json";
-
-const typescriptData = {
-  languageString: "TypeScript",
-  languageLetter: "t",
-  generatorURL: "https://github.com/ScottLogic/openapi-forge-typescript.git",
-};
-
-const csharpData = {
-  languageString: "CSharp",
-  languageLetter: "c",
-  generatorURL: "https://github.com/ScottLogic/openapi-forge-csharp.git",
-};
-
-function setupAndStartTests(generatorPath, arg1, arg2) {
-  shell.cd(generatorPath, log.shellOptions);
-
-  log.standard("Starting tests");
-  const test = shell.exec(`npm run test "${arg1}" "${arg2}"`, log.shellOptions);
-
-  shell.cd(__dirname, log.shellOptions);
-  return test.stdout.split("\n");
+function isJson(str) {
+  try {
+    JSON.parse(str);
+  } catch (e) {
+    return false;
+  }
+  return true;
 }
 
-function getGenerator(languageData, generatorOption) {
-  log.standard(
-    `\n${log.bold}${log.underline}${languageData.languageString}${log.resetStyling}`
-  );
-  let generatorPath = path.resolve(path.join("../../", generatorOption));
+function parseMessages(messages) {
+  // each test case starts with a testCaseStarted message, followed by a number of testStepFinished messages
+  const stepsForTestCase = [];
+  messages.forEach((message) => {
+    if (message.testCaseStarted) {
+      stepsForTestCase.push([]);
+    }
+    if (message.testStepFinished) {
+      stepsForTestCase[stepsForTestCase.length - 1].push(
+        message.testStepFinished
+      );
+    }
+  });
 
-  log.standard(
-    `Loading ${languageData.languageString} generator from '${generatorPath}'`
-  );
+  // determine the duration
+  const start = messages.filter((m) => m.testRunStarted)[0].testRunStarted
+    .timestamp.seconds;
+  const end = messages.filter((m) => m.testRunFinished)[0].testRunFinished
+    .timestamp.seconds;
 
-  // Check for local generator.
-  if (!fs.existsSync(generatorPath)) {
-    log.verbose(`Cannot find ${languageData.languageString} generator`);
-
-    // Local generator does not exist, clone from GitHub to temporary location
-    generatorPath = generatorResolver.getGenerator(languageData.generatorURL);
-  }
-  return generatorPath;
+  return {
+    scenarios: stepsForTestCase.length,
+    failed: stepsForTestCase.filter((steps) =>
+      steps.some((s) => s.testStepResult.status === "FAILED")
+    ).length,
+    passed: stepsForTestCase.filter((steps) =>
+      steps.every((s) => s.testStepResult.status === "PASSED")
+    ).length,
+    time: end - start,
+  };
 }
 
-function checkTestResultForErrors(result) {
-  if (result.failed !== 0) {
-    return 1;
-  }
-  if (result.undef !== 0) {
-    return 1;
-  }
-  if (result.skipped !== 0) {
-    return 1;
-  }
-  return 0;
-}
-
-async function testGenerators(options) {
-  let resultArray = {};
-  let exitCode = 0;
-
-  const curDir = process.cwd();
+function testGenerators(options) {
+  const aggregatedResults = {};
 
   log.setLogLevel(options.logLevel);
 
-  const typescript = options.generators.includes(typescriptData.languageLetter);
-  const csharp = options.generators.includes(csharpData.languageLetter);
-  if (!typescript && !csharp) {
-    throw new Error(
-      `No language to test. Please provide a language that you would like to test.`
-    );
-  }
-
-  shell.cd(__dirname, log.shellOptions);
-  if (typescript) {
-    // Test TypeScript generator
+  options.generators.forEach((generator) => {
     try {
-      const generatorPath = getGenerator(typescriptData, options.typescript);
-
-      const featurePath = path
-        .relative(generatorPath, path.join(__dirname, "../features/*.feature"))
-        .replaceAll("\\", "/");
-      const basePath = path
-        .relative(
-          path.join(generatorPath, "features/support"),
-          path.join(__dirname, "../src/generate")
-        )
-        .replaceAll("\\", "/");
-
-      const stdout = setupAndStartTests(generatorPath, featurePath, basePath);
-
-      const testResultParser = require(path.join(
-        generatorPath,
-        "testResultParser"
-      ));
-
-      const result = testResultParser.parse(stdout);
-
-      // check if failed/skipped/undefined steps in tests. If so OR them onto the exit code to stop overwriting previous errors
-      exitCode = exitCode | checkTestResultForErrors(result);
-
-      resultArray.TypeScript = result;
-
-      log.standard(`${typescriptData.languageString} testing complete`);
-    } catch (exception) {
-      log.logFailedTesting(typescriptData.languageString, exception);
-      exitCode = exitCode | 1;
-    } finally {
-      generatorResolver.cleanup();
-    }
-  }
-  if (csharp) {
-    // Test CSharp generator
-    try {
-      const generatorPath = getGenerator(csharpData, options.csharp);
-
-      const featurePath = path.relative(
-        path.join(generatorPath, "tests/FeaturesTests"),
-        path.join(__dirname, "../features/*.feature")
+      const generatorPath = path.resolve(
+        path.join(__dirname, "..", "..", generator)
       );
 
-      const stdout = setupAndStartTests(generatorPath, featurePath, "");
+      log.standard(`Starting tests for generator ${generator}`);
+      shell.cd(generatorPath, log.shellOptions);
+      const result = shell
+        .exec(`npm run test:generators`, log.shellOptions)
+        .stdout.split("\n")
+        .filter(isJson)
+        .map(JSON.parse);
+      shell.cd(__dirname, log.shellOptions);
 
-      const testResultParser = require(path.join(
-        generatorPath,
-        "testResultParser"
-      ));
-
-      const result = testResultParser.parse(stdout);
-
-      // check if failed/skipped/undefined steps in tests. If so OR them onto the exit code to stop overwriting previous errors
-      exitCode = exitCode | checkTestResultForErrors(result);
-
-      resultArray.CSharp = result;
-
-      log.standard(`${csharpData.languageString} testing complete`);
-    } catch (exception) {
-      log.logFailedTesting(csharpData.languageString, exception);
-      exitCode = exitCode | 1;
-    } finally {
-      generatorResolver.cleanup();
+      aggregatedResults[generator] = parseMessages(result);
+    } catch (e) {
+      log.error(`Error testing generator ${generator}: ${e}`);
     }
-  }
+  });
 
-  if (options.outputFile) {
-    if (typeof options.outputFile === "boolean")
-      options.outputFile = defaultResultFile;
-    fs.writeFileSync(
-      path.join(curDir, options.outputFile),
-      JSON.stringify(resultArray)
-    );
-  }
-
-  // Remove failure scenarios and present the results of the testing
-  if (Object.keys(resultArray).length) {
-    const languages = Object.keys(resultArray);
-    for (let xx = 0; xx < languages.length; xx++) {
-      delete resultArray[languages[xx]].failures;
-    }
-    if (!log.isQuiet()) console.table(resultArray);
-  }
-
-  process.exit(exitCode);
+  console.table(aggregatedResults);
 }
 
 module.exports = {
-  defaultResultFile,
   testGenerators,
 };


### PR DESCRIPTION
see:

https://github.com/ScottLogic/openapi-forge-typescript/pull/39
https://github.com/ScottLogic/openapi-forge-javascript/pull/2
https://github.com/ScottLogic/openapi-forge-csharp/pull/39

Updated the tests to use the [cucumber messages](https://github.com/cucumber/messages) format output. Note, this is not supported in C#, so have added a somewhat hacky solution.

Also, the tests are now hard-coded to assume that the generators and forge are in the same folder, removing the need for passing any arguments.