### PR TITLE
Fix: file encoding of binary files in template

### DIFF
--- a/src/generate.js
+++ b/src/generate.js
@@ -131,7 +131,7 @@ function processTemplateFactory(
       log.verbose("Copying to output location");
       // for other files, simply copy them to the output folder
       createNestedDirectories(schema, file, outputFolder);
-      fs.writeFileSync(`${outputFolder}/${file}`, source);
+      fs.copyFileSync(`${generatorTemplatesPath}/${file}`, `${outputFolder}/${file}`);
     }
   };
 }


### PR DESCRIPTION
This PR fixes a bug where template provided binary files are misencoded/corrupted during generation of the api client.