### PR TITLE
fix: test-generators command by reverting generate

### DIFF
--- a/src/forge/index.js
+++ b/src/forge/index.js
@@ -51,8 +51,7 @@ const forgeCommand = function (program) {
           process.env[optionName] = options[option];
         });
 
-        await generate(schema, generatorPath, options);
-        generatorResolver.cleanup();
+        await generate(schema, generatorPathOrUrl, options);
       });
 
       // add the additional options from the generator's config.json file

--- a/src/generate.js
+++ b/src/generate.js
@@ -162,13 +162,17 @@ function getFilesInFolders(basePath, partialPath = "") {
 
 // IMPORTANT: This function is used in the generators, so be careful when modifying!
 // See issue https://github.com/ScottLogic/openapi-forge/issues/158
-async function generate(schemaPathOrUrl, generatorPath, options) {
+async function generate(schemaPathOrUrl, generatorPathOrUrl, options) {
   log.setLogLevel(options.logLevel);
   log.logTitle();
   let exception = null;
   let numberOfDiscoveredModels = 0;
   let numberOfDiscoveredEndpoints = 0;
   try {
+    log.standard(`Loading generator from '${generatorPathOrUrl}'`);
+
+    let generatorPath = generatorResolver.getGenerator(generatorPathOrUrl);
+
     log.standard("Validating generator");
     validateGenerator(generatorPath);
 
@@ -270,6 +274,8 @@ async function generate(schemaPathOrUrl, generatorPath, options) {
     }
   } catch (e) {
     exception = e;
+  } finally {
+    generatorResolver.cleanup();
   }
 
   if (exception === null) {

--- a/test/generate.test.js
+++ b/test/generate.test.js
@@ -24,6 +24,7 @@ describe("generate", () => {
     fs.existsSync.mockReturnValue(true);
     fs.readFileSync.mockReturnValue(fakeSchema);
     generatorResolver.isUrl.mockReturnValue(false);
+    generatorResolver.getGenerator.mockImplementation((path) => path);
     Handlebars.compile.mockReturnValue(() => outCode);
 
     const generatorPackage = {


### PR DESCRIPTION
The test-generators command was no longer working following https://github.com/ScottLogic/openapi-forge/pull/160/files because of the change to the generate function in generate.js. This PR reverts the changes, but keeps the functionality needed for the generator-options command.

Hopefully this kind of error will be picked up much more easily when we've addressed https://github.com/ScottLogic/openapi-forge/issues/163