### PR TITLE
feat: change file exclude option to allow multiple exclude globs

### DIFF
--- a/src/forge/index.js
+++ b/src/forge/index.js
@@ -20,9 +20,9 @@ const forgeCommand = function (program) {
       "Git URL, file path or npm package of a language-specific generator"
     )
     .option(
-      "-e, --exclude <glob>",
-      "A glob pattern that excludes files from the generator in the output",
-      ""
+      "-e, --exclude <glob...>",
+      "A glob pattern or patterns that exclude files from the generator in the output",
+      []
     )
     .option(
       "-o, --output <path>",

--- a/src/generate.js
+++ b/src/generate.js
@@ -103,7 +103,10 @@ function processTemplateFactory(
   outputFolder
 ) {
   return async function (file) {
-    if (options.exclude && minimatch(file, options.exclude)) {
+    if (
+      options.exclude &&
+      options.exclude.some((excludeGlob) => minimatch(file, excludeGlob))
+    ) {
       return;
     }
     log.verbose(`\n${log.brightYellowForeground}${file}${log.resetStyling}`);


### PR DESCRIPTION
This will be useful in the Java generator, where it will be possible to do:

`openapi-forge forge features/schema.json . -o temp -e pom.xml .mvn/** .gitignore mvnw* *.md`

Our Java generator has parts of the template like the pom file which are useful for generating normally, but we don't want in a test context.