### PR TITLE
Resolver refactor

### DIFF
--- a/src/common/generatorResolver.js
+++ b/src/common/generatorResolver.js
@@ -27,7 +27,28 @@ function getGenerator(generatorPathOrUrl) {
       generatorPath = installGeneratorFromNPM(generatorPathOrUrl);
     }
   }
-  return generatorPath;
+  return {
+    path: generatorPath,
+    dispose: () => {
+      cleanup();
+    },
+  };
+}
+
+function cleanup() {
+  if (temporaryFolder) {
+    log.verbose(`Removing temporary folder ${temporaryFolder}`);
+    fs.rmSync(temporaryFolder, { recursive: true });
+    temporaryFolder = null;
+  }
+  if (npmPackage) {
+    const currentPath = process.cwd();
+    shell.cd(__dirname, log.shellOptions);
+    log.verbose(`Removing npm package ${npmPackage}`);
+    shell.exec(`npm uninstall ${npmPackage}`, log.shellOptions);
+    shell.cd(currentPath, log.shellOptions);
+    npmPackage = null;
+  }
 }
 
 function cloneGenerator(generatorPathOrUrl) {
@@ -92,24 +113,7 @@ function installGeneratorDependencies() {
   shell.exec(`npm install`, log.shellOptions);
 }
 
-function cleanup() {
-  if (temporaryFolder) {
-    log.verbose(`Removing temporary folder ${temporaryFolder}`);
-    fs.rmSync(temporaryFolder, { recursive: true });
-    temporaryFolder = null;
-  }
-  if (npmPackage) {
-    const currentPath = process.cwd();
-    shell.cd(__dirname, log.shellOptions);
-    log.verbose(`Removing npm package ${npmPackage}`);
-    shell.exec(`npm uninstall ${npmPackage}`, log.shellOptions);
-    shell.cd(currentPath, log.shellOptions);
-    npmPackage = null;
-  }
-}
-
 module.exports = {
   isUrl,
-  getGenerator,
-  cleanup,
+  getGenerator
 };

--- a/src/common/shell.js
+++ b/src/common/shell.js
@@ -1,0 +1,65 @@
+// This module exports a number of functions that are used to execute shell commands. Each function
+// ensures that the working directory is restored to its original value after the command has executed.
+
+const shell = require("shelljs");
+
+function gitClone(url, path, shellOptions) {
+  shell.exec(`git clone ${url} ${path}`, shellOptions);
+}
+
+function listInstalledPackages(path, shellOptions) {
+  const currentPath = process.cwd();
+  shell.cd(path, shellOptions);
+  const code = shell.exec(`npm list --depth=0`, shellOptions);
+  shell.cd(currentPath, shellOptions);
+  return code;
+}
+
+function installPackage(packageName, path, shellOptions) {
+  const currentPath = process.cwd();
+  shell.cd(path, shellOptions);
+  const code = shell.exec(`npm install ${packageName}`, shellOptions);
+  shell.cd(currentPath, shellOptions);
+  return code;
+}
+
+function installDependencies(path, shellOptions) {
+  const currentPath = process.cwd();
+  shell.cd(path, shellOptions);
+  // Do not run husky preparation script as it will cause unnecessary errors
+  shell.exec(`npm pkg delete scripts.prepare`, shellOptions);
+  shell.exec(`npm install`, shellOptions);
+  shell.cd(currentPath, shellOptions);
+}
+
+function uninstallPackage(npmPackage, path, shellOptions) {
+  const currentPath = process.cwd();
+  shell.cd(path, shellOptions);
+  shell.exec(`npm uninstall ${npmPackage}`, shellOptions);
+  shell.cd(currentPath, shellOptions);
+}
+
+// use partial application to adapt a function to a new signature, with a 'fixed' value
+// for the first argument
+const partial =
+  (fn, lastArg) =>
+  (...args) =>
+    fn(...args, lastArg);
+
+const exportedFns = {
+  gitClone,
+  listInstalledPackages,
+  installPackage,
+  installDependencies,
+  uninstallPackage,
+};
+
+module.exports = {
+  ...exportedFns,
+  // export a version of each function that has the shellOptions argument pre-filled
+  shellWithOptions: (options) =>
+    Object.keys(exportedFns).reduce((acc, key) => {
+      acc[key] = partial(exportedFns[key], options);
+      return acc;
+    }, {}),
+};

--- a/src/forge/index.js
+++ b/src/forge/index.js
@@ -41,7 +41,7 @@ const forgeCommand = function (program) {
       log.setLogLevel(options.logLevel);
 
       const generatorPath = generatorResolver.getGenerator(generatorPathOrUrl);
-      const configFile = path.join(generatorPath, "config.json");
+      const configFile = path.join(generatorPath.path, "config.json");
 
       // re-configure the command to generate the API
       command.allowUnknownOption(false).action(async (_, __, options) => {

--- a/src/generate.js
+++ b/src/generate.js
@@ -154,12 +154,14 @@ function getFilesInFolders(basePath, partialPath = "") {
 async function generate(schemaPathOrUrl, generatorPathOrUrl, options) {
   log.logTitle();
   let exception = null;
+  let generator = null;
   let numberOfDiscoveredModels = 0;
   let numberOfDiscoveredEndpoints = 0;
   try {
     log.standard(`Loading generator from '${generatorPathOrUrl}'`);
 
-    let generatorPath = generatorResolver.getGenerator(generatorPathOrUrl);
+    generator = generatorResolver.getGenerator(generatorPathOrUrl);
+    const generatorPath = generator.path;
 
     // load the OpenAPI schema
     log.standard(`Loading schema from '${schemaPathOrUrl}'`);
@@ -270,7 +272,7 @@ async function generate(schemaPathOrUrl, generatorPathOrUrl, options) {
   } catch (e) {
     exception = e;
   } finally {
-    generatorResolver.cleanup();
+    generator.dispose();
   }
 
   if (exception === null) {

--- a/src/generate.js
+++ b/src/generate.js
@@ -51,20 +51,6 @@ function cloneSchema(schema) {
   return JSON.parse(JSON.stringify(schema));
 }
 
-function validateGenerator(generatorPath) {
-  if (!fs.existsSync(generatorPath)) {
-    throw new Error(
-      `Generator path ${generatorPath} does not exist, check that the path points to a valid generator`
-    );
-  }
-
-  if (!fs.existsSync(`${generatorPath}/template`)) {
-    throw new Error(
-      `Generator path ${generatorPath} does not contain a template folder, check that the path points to a valid generator`
-    );
-  }
-}
-
 function getFileName(fileName, tagName = "") {
   let newFileName = fileName.slice(0, fileName.indexOf("."));
   if (tagName !== "") newFileName += helpers.capitalizeFirst(tagName);
@@ -174,9 +160,6 @@ async function generate(schemaPathOrUrl, generatorPathOrUrl, options) {
     log.standard(`Loading generator from '${generatorPathOrUrl}'`);
 
     let generatorPath = generatorResolver.getGenerator(generatorPathOrUrl);
-
-    log.standard("Validating generator");
-    validateGenerator(generatorPath);
 
     // load the OpenAPI schema
     log.standard(`Loading schema from '${schemaPathOrUrl}'`);

--- a/src/generatorOptions/generatorOptions.js
+++ b/src/generatorOptions/generatorOptions.js
@@ -3,14 +3,15 @@ const path = require("path");
 
 const { Option, Command } = require("commander");
 
-const generatorResolver = require("../common/generatorResolver");
+const { getGenerator } = require("../common/generatorResolver");
 
 const generatorOptionsPrefix = "generator.";
 
 // generates the help text for the additional options that a generator supports
 async function generatorOptionsHelp(generatorPathOrUrl) {
   let optionsHelp = "";
-  const generatorPath = generatorResolver.getGenerator(generatorPathOrUrl);
+  const generator = getGenerator(generatorPathOrUrl);
+  const generatorPath = generator.path;
   const configFile = path.join(generatorPath, "config.json");
 
   if (!fs.existsSync(configFile)) {
@@ -34,7 +35,7 @@ async function generatorOptionsHelp(generatorPathOrUrl) {
     optionsHelp += lines.join("\n");
   }
 
-  generatorResolver.cleanup();
+  generator.dispose();
 
   return optionsHelp;
 }

--- a/test/common/generatorResolver.test.js
+++ b/test/common/generatorResolver.test.js
@@ -1,0 +1,67 @@
+const path = require("path");
+const fs = require("fs");
+const { getGenerator } = require("../../src/common/generatorResolver");
+const log = require("../../src/common/log");
+log.setLogLevel("quiet");
+
+describe("generatorResolver", () => {
+  describe("generator specified as a filepath", () => {
+    it("should return the filepath given", async () => {
+      const generatorPath = path.join(__dirname, "validGenerator");
+      const generator = await getGenerator(generatorPath);
+      expect(generator.path).toEqual(generatorPath);
+    });
+
+    it("should throw an error if the filepath doesn't point to a valid generator", async () => {
+      // we'll just point to some random directory
+      const generatorPath = path.join(__dirname);
+      expect(() => {
+        getGenerator(generatorPath);
+      }).toThrow();
+    });
+  });
+
+  describe("generator specified as a git repo", () => {
+    it("should clone the repo into a temporary directory", async () => {
+      const generator = await getGenerator(
+        "https://github.com/ScottLogic/openapi-forge-csharp.git"
+      );
+      // validate via the presence of a package.json file
+      const packageJsonPath = path.join(generator.path, "package.json");
+      expect(fs.existsSync(packageJsonPath)).toEqual(true);
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+      expect(packageJson.name).toEqual("openapi-forge-csharp");
+
+      // clean up
+      generator.dispose();
+    });
+
+    it("should cleanup on disposal", async () => {
+      const generator = await getGenerator(
+        "https://github.com/ScottLogic/openapi-forge-csharp.git"
+      );
+      generator.dispose();
+      expect(fs.existsSync(generator.path)).toEqual(false);
+    });
+  });
+
+  describe("generator specified as an npm package", () => {
+    it("should install the package in a temporary folder", async () => {
+      const generator = await getGenerator("openapi-forge-typescript");
+      // validate via the presence of a package.json file
+      const packageJsonPath = path.join(generator.path, "package.json");
+      expect(fs.existsSync(packageJsonPath)).toEqual(true);
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+      expect(packageJson.name).toEqual("openapi-forge-typescript");
+
+      // clean up
+      generator.dispose();
+    });
+
+    it("should cleanup on disposal", async () => {
+      const generator = await getGenerator("openapi-forge-typescript");
+      generator.dispose();
+      expect(fs.existsSync(generator.path)).toEqual(false);
+    });
+  });
+});

--- a/test/common/validGenerator/template/.gitignore
+++ b/test/common/validGenerator/template/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/test/generate.test.js
+++ b/test/generate.test.js
@@ -26,7 +26,10 @@ describe("generate", () => {
     fs.existsSync.mockReturnValue(true);
     fs.readFileSync.mockReturnValue(fakeSchema);
     generatorResolver.isUrl.mockReturnValue(false);
-    generatorResolver.getGenerator.mockImplementation((path) => path);
+    generatorResolver.getGenerator.mockImplementation((path) => ({
+      path,
+      dispose: () => {},
+    }));
     Handlebars.compile.mockReturnValue(() => outCode);
 
     const generatorPackage = {

--- a/test/generatorOptions.test.js
+++ b/test/generatorOptions.test.js
@@ -11,7 +11,10 @@ jest.mock("../src/common/generatorResolver");
 
 describe("generate", () => {
   beforeAll(() => {
-    generatorResolver.getGenerator.mockImplementation((path) => path);
+    generatorResolver.getGenerator.mockImplementation((path) => ({
+      path,
+      dispose: () => {},
+    }));
   });
 
   beforeEach(() => {


### PR DESCRIPTION
Given that we have a few issues (#198 #195 #171) relating to the resolver, I wanted to do a bit of a refactor before tackling the specific bugs. This PR doesn't address them directly, but should make it easier to fix them in future. Changes include:

 - moving shell logic into its own module
 - resolver now returns an object, with a `dispose` function for cleanup
 - unit tested!
 - npm install now uses temp folder rather than mutating the current project package.json

